### PR TITLE
fix(filters): éviter le doublon de titre catégorie/sous-catégorie en grec

### DIFF
--- a/client/src/components/Filter/FilterItem/CategoriesFilterItem.tsx
+++ b/client/src/components/Filter/FilterItem/CategoriesFilterItem.tsx
@@ -12,7 +12,8 @@ import {
   toIdArray,
   getFieldValue,
   getName,
-  getKeywordName
+  getKeywordName,
+  getStringField,
 } from './utils'
 import { FilterSearch } from '../FilterSearch/FilterSearch'
 
@@ -59,12 +60,16 @@ export const CategoriesFilterItem = ({
           .map(subCategory => ({
             id: subCategory.id,
             name: getName(subCategory, isGreek),
+            // Nom anglais (canonique) servant à détecter la sous-catégorie
+            // homonyme de la catégorie, indépendamment de la langue affichée.
+            nameEn: getStringField(subCategory, 'Name_EN'),
             keywords: getKeywordsBySubCategoryId(subCategory.id),
           }))
 
         return {
           id: category.id,
           name: getName(category, isGreek),
+          nameEn: getStringField(category, 'Name_EN'),
           keywords: [] as AirtableRecord[],
           subCategories: subCategoryItems,
         }
@@ -161,10 +166,10 @@ export const CategoriesFilterItem = ({
     <Accordion type="multiple">
       {filteredCategoriesWithChildren.map(category => {
         const sameNameSubcategories = category.subCategories.filter(
-          sub => sub.name === category.name,
+          sub => sub.nameEn === category.nameEn,
         )
         const otherSubcategories = category.subCategories.filter(
-          sub => sub.name !== category.name,
+          sub => sub.nameEn !== category.nameEn,
         )
         const categorySameNameKeywords = sameNameSubcategories.flatMap(sub => sub.keywords)
         const categoryChildKeywords = [...category.keywords, ...categorySameNameKeywords]

--- a/client/src/components/ui/accordion.tsx
+++ b/client/src/components/ui/accordion.tsx
@@ -33,7 +33,7 @@ function AccordionTrigger({
       <AccordionPrimitive.Trigger
         data-slot="accordion-trigger"
         className={cn(
-          'flex items-start grow justify-between p-2 font-medium',
+          'flex items-start grow justify-between p-2 font-medium text-left',
           className,
         )}
         {...props}


### PR DESCRIPTION
## Problème

En grec, certaines catégories affichaient un titre dupliqué quand une sous-catégorie portait le même nom traduit que sa catégorie parent.

## Solution

La comparaison pour détecter l'homonyme utilise désormais `Name_EN` (valeur canonique) au lieu du nom traduit. Cela fonctionne indépendamment de la langue affichée.

## Test
- [ ] Vérifier les filtres hiérarchiques (Vulnerability, Legal & Procedural Issues) en anglais → pas de doublon
- [ ] Passer en grec → pas de doublon de titre catégorie

🤖 Generated with [Claude Code](https://claude.com/claude-code)