### PR TITLE
feat(ui): scrollbar cachée, alignement filtres, max-width 1600px

### DIFF
--- a/client/src/components/Layout/GlobalLayout.tsx
+++ b/client/src/components/Layout/GlobalLayout.tsx
@@ -3,7 +3,7 @@ import { Outlet } from 'react-router-dom'
 
 export const GlobalLayout = () => {
   return (
-    <div className="app mx-auto my-0 w-full xl:max-w-315">
+    <div className="app mx-auto my-0 w-full xl:max-w-400">
       <HeaderComponent />
       <main className="main-content px-4 xl:px-0">
         <Outlet />

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -135,3 +135,13 @@
     @apply bg-background text-foreground;
   }
 }
+
+@layer utilities {
+  .scrollbar-hidden {
+    scrollbar-width: none;
+    -ms-overflow-style: none;
+  }
+  .scrollbar-hidden::-webkit-scrollbar {
+    display: none;
+  }
+}

--- a/client/src/pages/CaselawPage.tsx
+++ b/client/src/pages/CaselawPage.tsx
@@ -25,13 +25,16 @@ export const CaselawPage = () => {
       />
       <div className="flex flex-wrap xl:gap-10">
         <div className="flex-auto xl:w-72 xl:flex-none xl:shrink-0">
-          <div className="xl:sticky xl:top-20 xl:max-h-[calc(100vh-100px)] xl:overflow-y-auto">
-            <FilterPanel
-              onApplyFilters={fetchFilteredCaselaws}
-              minDate={dateBounds.minDate}
-              maxDate={dateBounds.maxDate}
-              count={caselawRecords.length}
-            />
+          <div className="xl:sticky xl:top-13.5 relative">
+            <div className="xl:max-h-[calc(100vh-54px)] xl:overflow-y-auto scrollbar-hidden">
+              <FilterPanel
+                onApplyFilters={fetchFilteredCaselaws}
+                minDate={dateBounds.minDate}
+                maxDate={dateBounds.maxDate}
+                count={caselawRecords.length}
+              />
+            </div>
+            <div className="pointer-events-none absolute bottom-0 left-0 right-0 h-12 bg-gradient-to-t from-white to-transparent hidden xl:block" />
           </div>
         </div>
         <div className="w-full flex-auto bg-white xl:w-222">


### PR DESCRIPTION
## Changements

### 1. Scrollbar filtre cachée + indicateur de scroll
- La scrollbar native du panel filtre est masquée (`scrollbar-hidden`)
- Un gradient blanc `from-white to-transparent` en `absolute bottom-0` indique visuellement qu'il y a du contenu à scroller

### 2. Alignement vertical filtres / Sort by
- Le panel filtre est maintenant sticky à `xl:top-13.5` (54px) au lieu de `xl:top-20` (80px), pour s'aligner avec la barre Sort by / recherche
- `max-h` ajustée à `calc(100vh-54px)` en conséquence

### 3. Max-width du site à 1600px
- `xl:max-w-315` (1260px) → `xl:max-w-400` (1600px)
- Les colonnes `flex-auto` s'adaptent automatiquement

## Test
- [ ] Desktop large (>1600px) : contenu centré et bien dimensionné
- [ ] Panel filtre : scrollbar invisible, gradient visible en bas quand contenu dépasse
- [ ] Sort by et haut du panel filtre visuellement alignés au scroll

🤖 Generated with [Claude Code](https://claude.com/claude-code)