### PR TITLE
fix(filters): match exact des pays (Mali != Somalia) + masquer keywor…

### DIFF
--- a/client/src/hooks/useAirtableCaselaw.ts
+++ b/client/src/hooks/useAirtableCaselaw.ts
@@ -94,10 +94,13 @@ const buildFilterFormula = (selectedFilters: SelectedFilters): string => {
       const orClauses = values.map((value) => {
         const escapedValue = escapeFormulaValue(value)
         if (column === 'Keywords') {
+          // Keywords = champ multi-valeurs → recherche par sous-chaîne (existant).
           return `SEARCH(LOWER("${escapedValue}"), LOWER({Keywords}))`
         }
 
-        return `SEARCH(LOWER("${escapedValue}"), LOWER({${column}}))`
+        // Champs à valeur unique → égalité EXACTE. SEARCH matchait la sous-chaîne
+        // ("Mali" matchait "Somalia"). TRIM absorbe les espaces parasites.
+        return `LOWER(TRIM({${column}})) = LOWER(TRIM("${escapedValue}"))`
       }).join(',')
 
       return values.length > 1 ? `OR(${orClauses})` : orClauses

--- a/client/src/hooks/useAirtableFilter.ts
+++ b/client/src/hooks/useAirtableFilter.ts
@@ -85,6 +85,9 @@ export const useAirtableFilter = () => {
               }
             }
             else if (tableName === AirtableBaseNameEnum.Keywords) {
+              // On n'affiche que les keywords rattachés à au moins une décision
+              // (Count_Caselaws > 0), comme les autres filtres.
+              selectConfig.filterByFormula = 'AND({Count_Caselaws} != BLANK(), {Count_Caselaws} > 0)'
               selectConfig.sort = [{ field: 'Index', direction: 'asc' }]
             }
             const records = await airtableService.fetchRecordsFromTable({


### PR DESCRIPTION
🐛 Fix filtres — correspondance exacte des pays & keywords sans décision
Cette PR corrige deux bugs sur le filtrage des décisions.

1. Filtre pays : « Mali » remontait aussi « Somalia »
_Le filtrage utilisait SEARCH() (recherche de sous-chaîne) sur les colonnes à valeur unique. Résultat : « Mali » matchait « Somalia »._
➡️ Les champs à valeur unique (pays, outcome, type de demande, procédure, autorité) utilisent désormais une égalité exacte (LOWER(TRIM(...)) = ...), avec TRIM pour absorber d'éventuels espaces parasites dans la donnée. Les keywords (champ multi-valeurs) gardent la recherche par sous-chaîne, inchangée.

2. Filtres keywords : des valeurs sans aucune décision étaient affichées
_Le chargement des keywords ne filtrait pas sur Count_Caselaws, contrairement aux autres filtres._
➡️ On ne récupère plus que les keywords rattachés à au moins une décision (Count_Caselaws > 0), comme les filtres pays/outcome/etc.
