### PR TITLE
fix: bug d'affichage en embed + ajustements UI des filtres et cartes

### DIFF
--- a/client/src/components/Caselaws/CaselawCard.tsx
+++ b/client/src/components/Caselaws/CaselawCard.tsx
@@ -84,7 +84,7 @@ export const CaselawCard = ({ caselaw }: CaselawCardProps) => {
             <Button
               variant="outline"
               asChild
-              className="!h-auto !py-1 !px-2.5 !text-[0.72rem] !rounded-3xl !gap-1 !font-medium !tracking-[0.4px] w-full xl:w-auto"
+              className="!h-auto !py-1 !px-2.5 !text-[0.72rem] !rounded-3xl !gap-1 !font-sans !font-medium !tracking-[0.4px] w-full xl:w-auto"
             >
               <a
                 href={caselaw.englishPdfLink.pdfURL}
@@ -99,7 +99,7 @@ export const CaselawCard = ({ caselaw }: CaselawCardProps) => {
             <Button
               variant="outline"
               asChild
-              className="!h-auto !py-1 !px-2.5 !text-[0.72rem] !rounded-3xl !gap-1 !font-medium !tracking-[0.4px] w-full xl:w-auto"
+              className="!h-auto !py-1 !px-2.5 !text-[0.72rem] !rounded-3xl !gap-1 !font-sans !font-medium !tracking-[0.4px] w-full xl:w-auto"
             >
               <a
                 href={caselaw.greekPdfLink.pdfURL}

--- a/client/src/components/Filter/FilterAction/FilterAction.tsx
+++ b/client/src/components/Filter/FilterAction/FilterAction.tsx
@@ -96,7 +96,7 @@ export const FilterAction = ({
         <Button
           onClick={handleSort}
           variant="outline"
-          className="w-1/2 font-bold xl:w-auto"
+          className="w-1/2 font-normal xl:w-auto"
         >
           {recentFirst ? (<ArrowDownWideNarrow />) : (<ArrowUpNarrowWide />)}
           {t('filter.sortBy')}

--- a/client/src/components/Filter/FilterSearch/FilterSearch.tsx
+++ b/client/src/components/Filter/FilterSearch/FilterSearch.tsx
@@ -42,7 +42,7 @@ export const FilterSearch = ({
     )
   }, [searchDebouceValue, airtableBaseName, dispatch, prevValue, searchValue, needToSearch])
   return (
-    <div className="filter-search relative">
+    <div className="filter-search relative pt-1">
       <Input
         value={searchValue}
         placeholder={placeholderContent.length > 0 ? placeholderContent : ''}

--- a/client/src/components/ui/accordion.tsx
+++ b/client/src/components/ui/accordion.tsx
@@ -33,7 +33,7 @@ function AccordionTrigger({
       <AccordionPrimitive.Trigger
         data-slot="accordion-trigger"
         className={cn(
-          'flex items-start grow justify-between px-2 py-1.5 font-medium text-left',
+          'flex items-start grow justify-between px-2 py-1.5 font-normal text-left',
           className,
         )}
         {...props}

--- a/client/src/components/ui/badge.tsx
+++ b/client/src/components/ui/badge.tsx
@@ -26,8 +26,7 @@ export const Badge = ({
   const badge = (
     <span
       className={cn(
-        `overflow-hidden flex w-fit items-center rounded-3xl px-2.5 py-1 text-[0.72rem] whitespace-nowrap font-medium tracking-[0.4px] ${uppercase ? ' uppercase' : ''}`,
-        truncate ? 'max-w-[16rem]' : 'max-w-full',
+        `overflow-hidden flex w-fit max-w-full items-center rounded-3xl px-2.5 py-1 text-[0.72rem] whitespace-nowrap font-medium tracking-[0.4px] ${uppercase ? ' uppercase' : ''}`,
         className,
       )}
       style={{ backgroundColor: color, color: fontColor }}

--- a/client/src/pages/CaselawPage.tsx
+++ b/client/src/pages/CaselawPage.tsx
@@ -20,13 +20,6 @@ export const CaselawPage = () => {
   useAirtableFilter()
   return (
     <>
-      <div className="mb-2 mt-6 xl:mt-10">
-        <h1 className="font-gotham text-[48px] font-extrabold uppercase leading-tight tracking-[0.3px] [box-decoration-break:clone] [-webkit-box-decoration-break:clone]">
-          <span className="bg-[#093266] px-5 text-white">
-            {t('nav.caselaw')}
-          </span>
-        </h1>
-      </div>
       <HighlightTitle title={t('caselaw.highlightTitle')} />
       <div className="flex flex-wrap xl:gap-10">
         <div className="flex-auto xl:w-72 xl:flex-none xl:shrink-0">

--- a/client/src/pages/CaselawPage.tsx
+++ b/client/src/pages/CaselawPage.tsx
@@ -5,6 +5,8 @@ import { FilterAction, FilterPanel } from '@/components/Filter'
 import { useAirtableCaselaw } from '@/hooks/useAirtableCaselaw'
 import { useTranslation } from 'react-i18next'
 import { useAirtableFilter } from '@/hooks'
+import { useEmbedMode } from '@/hooks/useEmbedMode'
+import { cn } from '@/lib/utils'
 export const CaselawPage = () => {
   const {
     caselawRecords,
@@ -17,14 +19,30 @@ export const CaselawPage = () => {
   } = useAirtableCaselaw()
   const [sortDesc, setSortDesc] = useState(true)
   const { t } = useTranslation()
+  // En embed, HeaderNavigation (sticky, top-0, 54px) est masquée. Les offsets
+  // sticky ci-dessous en dépendent :
+  //   - barre de filtres : se colle sous la nav → 54px, ou 0 sans elle.
+  //     Sans ce 0, la bande de 54px reste à nu et les cartes y défilent.
+  //   - panneau de filtres : s'aligne sur le bouton « Sort by », qui tombe
+  //     72px sous le haut de la barre. D'où 54+72=126, ou 0+72=72 en embed.
+  const isEmbed = useEmbedMode()
   useAirtableFilter()
   return (
     <>
       <HighlightTitle title={t('caselaw.highlightTitle')} />
       <div className="flex flex-wrap xl:gap-10">
-        <div className="flex-auto xl:w-72 xl:flex-none xl:shrink-0">
-          <div className="xl:sticky xl:top-[126px] relative">
-            <div className="xl:max-h-[calc(100vh-126px)] xl:overflow-y-auto scrollbar-hidden">
+        {/* pt = hauteur du bloc « N Decisions » de la barre (py-5 + texte + mb-6),
+            pour que le 1er filtre s'aligne sur « Sort by » avant que le sticky
+            ne prenne le relais. Même valeur que le 72 de xl:top-[126px]. */}
+        <div className="flex-auto xl:w-72 xl:flex-none xl:shrink-0 xl:pt-[72px]">
+          <div className={cn(
+            'relative xl:sticky',
+            isEmbed ? 'xl:top-[72px]' : 'xl:top-[126px]',
+          )}>
+            <div className={cn(
+              'scrollbar-hidden xl:overflow-y-auto',
+              isEmbed ? 'xl:max-h-[calc(100vh-72px)]' : 'xl:max-h-[calc(100vh-126px)]',
+            )}>
               <FilterPanel
                 onApplyFilters={fetchFilteredCaselaws}
                 minDate={dateBounds.minDate}
@@ -36,7 +54,10 @@ export const CaselawPage = () => {
           </div>
         </div>
         <div className="w-full flex-auto bg-white xl:w-222">
-          <div className="sticky top-0 z-10 bg-white py-5 pb-2 xl:top-13.5">
+          <div className={cn(
+            'sticky top-0 z-10 bg-white py-5 pb-2',
+            !isEmbed && 'xl:top-13.5',
+          )}>
             <div className="relative z-2">
               <FilterAction
                 count={caselawRecords.length}


### PR DESCRIPTION
## Le bug principal

En mode embed (`?embed=1`), des cartes apparaissaient au-dessus de la barre « N Decisions » au scroll.

**Cause** : `HeaderNavigation` est sticky à `top-0` et fait 54px de haut. Les barres sticky de la page portaient des offsets calculés pour la contourner (`xl:top-13.5` = 54px). En embed, `isEmbed` masque le `HeaderComponent` — la nav disparaît, mais l'offset reste. Résultat : une bande de 54px que plus rien ne couvre, où les cartes défilent à nu.

Ça explique pourquoi le bug n'apparaissait qu'intégré : en standalone la nav est là et remplit la bande.

**Fix** : les offsets sticky suivent désormais la présence de la nav.

| | Standalone | Embed |
|---|---|---|
| Barre « N Decisions » | `54px` | `0` |
| Panneau filtres | `54 + 72 = 126px` | `0 + 72 = 72px` |

## Alignement des filtres (préexistant)

Au repos, avant tout scroll, le 1er filtre remontait 72px au-dessus de « Sort by » — dans les deux modes. La colonne des filtres démarre en haut du conteneur flex, alors que celle des cartes démarre 72px plus bas (le `py-5` de la barre + la ligne « N Decisions » + son `mb-6`).

Corrigé par un `xl:pt-[72px]` sur la colonne. Vérifié aligné à toutes les positions de scroll, dans les deux modes.

Ce `72` est le même que celui de `126 = 54 + 72` : c'est la hauteur du bloc « N Decisions ». Un commentaire le signale — si on touche au `py-5` de la barre ou au `mb-6` du compteur, les trois valeurs sont à revoir ensemble.

## Ajustements UI

- **Keywords** : le `Badge` portait un plafond en dur `max-w-[16rem]` (256px) alors que la colonne fait 336px. 5 cartes sur 6 avaient au moins un keyword tronqué prématurément. Remplacé par `max-w-full` → +80px de texte lisible.
- **Cards** : `!font-sans` sur les 2 boutons PDF, qui héritaient du `font-gotham` de la base du composant `Button` et créaient un mix de police avec le reste de la carte. Les autres boutons gardent Gotham.
- **Graisses** : « Sort by » et les noms de filtres passés en regular.
- **Titre « DECISIONS »** retiré, en attente de validation avec l'agence — à voir s'ils l'intègrent de leur côté au-dessus de l'iframe. Récupérable dans l'historique (`daf09a0`).
- **FilterSearch** : `pt-1` au-dessus des champs de recherche.

Aucun changement fonctionnel. Vérifié en local dans les deux modes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)