### PR TITLE
fix(advocacy): format européen des nombres + arrivées de Crète manquantes

### DIFF
--- a/client/src/components/Indicators/ApplicationsEvolutionGreeceDetails.tsx
+++ b/client/src/components/Indicators/ApplicationsEvolutionGreeceDetails.tsx
@@ -70,15 +70,15 @@ export function ApplicationsEvolutionGreeceDetails({
           <div className="grid grid-cols-2 gap-4 sm:grid-cols-3">
             <StatCard
               label={t('statistics.totalFirstTime', { start: firstYear, end: lastYear })}
-              value={totals.first.toLocaleString()}
+              value={totals.first.toLocaleString('fr-FR')}
             />
             <StatCard
               label={t('statistics.totalSubsequent', { start: firstYear, end: lastYear })}
-              value={totals.subsequent.toLocaleString()}
+              value={totals.subsequent.toLocaleString('fr-FR')}
             />
             <StatCard
               label={t('statistics.total', { start: firstYear, end: lastYear })}
-              value={totals.total.toLocaleString()}
+              value={totals.total.toLocaleString('fr-FR')}
             />
           </div>
 

--- a/client/src/components/Indicators/ArrivalsGreeceDetails.tsx
+++ b/client/src/components/Indicators/ArrivalsGreeceDetails.tsx
@@ -40,6 +40,7 @@ const REGION_DEFS: Record<string, RegionDef> = {
 }
 
 const SEA_ISLANDS: { key: keyof ArrivalsGreeceYearly, label: string, color: string }[] = [
+  { key: 'crete', label: 'Crete', color: '#4f46e5' },
   { key: 'lesvos', label: 'Lesvos', color: '#3b82f6' },
   { key: 'chios', label: 'Chios', color: '#4f8ff7' },
   { key: 'samos', label: 'Samos', color: '#6366f1' },

--- a/client/src/components/Indicators/AsylumApplicationsDetails.tsx
+++ b/client/src/components/Indicators/AsylumApplicationsDetails.tsx
@@ -26,11 +26,6 @@ import type { AsylumApplicationRecord } from '@/hooks/useAsylumApplications'
 import type { IndicatorCustomText } from '@/hooks/useIndicatorCustomTexts'
 import { useTranslation } from 'react-i18next'
 
-function fmtK(n: number): string {
-  if (n >= 1_000) return `${Math.round(n / 1_000)}k`
-  return n.toLocaleString('en-US')
-}
-
 export function AsylumApplicationsDetails({
   records,
   loading,
@@ -169,7 +164,7 @@ export function AsylumApplicationsDetails({
             {mostRecentData && (
               <div className="rounded-lg border border-gray-200 p-5">
                 <p className="text-6xl font-bold text-gray-900 leading-none tabular-nums">
-                  {fmtK(mostRecentData.first_time_applicants)}
+                  {mostRecentData.first_time_applicants.toLocaleString('fr-FR')}
                 </p>
                 <p className="text-sm text-gray-600 mt-2">
                   {t('statistics.firstTimeApplicantsLabel')} in {mostRecentData.year}

--- a/client/src/components/Indicators/AsylumApplicationsEvolutionInGreeceDetails.tsx
+++ b/client/src/components/Indicators/AsylumApplicationsEvolutionInGreeceDetails.tsx
@@ -147,11 +147,11 @@ function ByPeriod({
       <div className="grid grid-cols-2 gap-4 sm:grid-cols-3">
         <StatCard
           label={t('statistics.totalFirstTime', { start: firstYear, end: lastYear })}
-          value={totalFirstTime.toLocaleString()}
+          value={totalFirstTime.toLocaleString('fr-FR')}
         />
         <StatCard
           label={t('statistics.totalSubsequent', { start: firstYear, end: lastYear })}
-          value={totalSubSequent.toLocaleString()}
+          value={totalSubSequent.toLocaleString('fr-FR')}
         />
       </div>
 
@@ -380,7 +380,7 @@ export function AsylumApplicationsEvolutionInGreeceDetails({
                 <p className="text-sm font-bold text-gray-900 mb-4">{subtitle}</p>
               )}
               <p className="text-6xl font-bold text-gray-900 leading-none tabular-nums">
-                {Number(keyFigure.value).toLocaleString()}
+                {Number(keyFigure.value).toLocaleString('fr-FR')}
               </p>
               <p className="text-sm text-gray-600 mt-2">
                 {keyFigure.firstYear} - {keyFigure.lastYear}

--- a/client/src/components/Indicators/AsylumSeekersCampsDetails.tsx
+++ b/client/src/components/Indicators/AsylumSeekersCampsDetails.tsx
@@ -388,7 +388,7 @@ export function AsylumSeekersCampsDetails({
                   <p className="text-sm font-bold text-gray-900 mb-4">{subtitle}</p>
                 )}
                 <p className="text-6xl font-bold text-gray-900 leading-none tabular-nums">
-                  {Number(keyFigure.total).toLocaleString()}
+                  {Number(keyFigure.total).toLocaleString('fr-FR')}
                 </p>
                 <p className="text-sm text-gray-600 mt-2">
                   In {keyFigure.date}

--- a/client/src/components/Indicators/CountryMapPopup.tsx
+++ b/client/src/components/Indicators/CountryMapPopup.tsx
@@ -11,8 +11,8 @@ export function CountryMapPopup({ record, perCapita }: Props) {
   const { t } = useTranslation()
   const fmt = (n: number) =>
     perCapita
-      ? n.toLocaleString('en-US', { maximumFractionDigits: 2 })
-      : n.toLocaleString('en-US')
+      ? n.toLocaleString('fr-FR', { maximumFractionDigits: 2 })
+      : n.toLocaleString('fr-FR')
 
   const rows = [
     {

--- a/client/src/components/Indicators/CourtAsylumProceduresDetails.tsx
+++ b/client/src/components/Indicators/CourtAsylumProceduresDetails.tsx
@@ -54,7 +54,7 @@ function TreeRow({
           </span>
         </span>
       </td>
-      <td className="px-4 py-2 text-right text-sm">{value.toLocaleString()}</td>
+      <td className="px-4 py-2 text-right text-sm">{value.toLocaleString('fr-FR')}</td>
       <td className="px-4 py-2 text-right text-sm text-gray-400">{pct}</td>
     </tr>
   )
@@ -175,7 +175,7 @@ function AnnulmentsCard({ records }: { records: AnnulmentRecord[] }) {
                   <Cell key={entry.name} fill={entry.color} />
                 ))}
               </Pie>
-              <PieTooltip formatter={value => (value != null ? Number(value).toLocaleString() : '')} />
+              <PieTooltip formatter={value => (value != null ? Number(value).toLocaleString('fr-FR') : '')} />
             </PieChart>
           </ChartContainer>
           <div className="w-full space-y-2 px-2">
@@ -183,7 +183,7 @@ function AnnulmentsCard({ records }: { records: AnnulmentRecord[] }) {
               <div key={d.name} className="flex items-center gap-2">
                 <div className="h-3 w-3 flex-shrink-0 rounded-full" style={{ backgroundColor: d.color }} />
                 <span className="text-sm text-gray-700">{d.name}</span>
-                <span className="ml-auto text-sm font-semibold text-gray-800">{d.value.toLocaleString()}</span>
+                <span className="ml-auto text-sm font-semibold text-gray-800">{d.value.toLocaleString('fr-FR')}</span>
               </div>
             ))}
           </div>
@@ -319,7 +319,7 @@ function LegalAidDonut({ records }: { records: LegalAidApplicationRecord[] }) {
                     <Cell key={entry.name} fill={entry.color} />
                   ))}
                 </Pie>
-                <PieTooltip formatter={value => (value != null ? Number(value).toLocaleString() : '')} />
+                <PieTooltip formatter={value => (value != null ? Number(value).toLocaleString('fr-FR') : '')} />
               </PieChart>
             </ChartContainer>
             <div className="w-full space-y-2 px-2">
@@ -328,7 +328,7 @@ function LegalAidDonut({ records }: { records: LegalAidApplicationRecord[] }) {
                   <div className="h-3 w-3 flex-shrink-0 rounded-full" style={{ backgroundColor: d.color }} />
                   <span className="text-sm text-gray-700">{d.name}</span>
                   <span className="ml-auto text-xs text-gray-400">{total > 0 ? `${Math.round((d.value / total) * 100)}%` : ''}</span>
-                  <span className="text-sm font-semibold text-gray-800">{d.value.toLocaleString()}</span>
+                  <span className="text-sm font-semibold text-gray-800">{d.value.toLocaleString('fr-FR')}</span>
                 </div>
               ))}
             </div>

--- a/client/src/components/Indicators/EuropeRegionMap.tsx
+++ b/client/src/components/Indicators/EuropeRegionMap.tsx
@@ -74,10 +74,8 @@ function applyMapData(
 }
 
 function formatValue(n: number, perCapita: boolean) {
-  if (perCapita) return n.toLocaleString('en-US', { maximumFractionDigits: 2 })
-  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`
-  if (n >= 1_000) return `${(n / 1_000).toFixed(0)}K`
-  return n.toLocaleString('en-US')
+  if (perCapita) return n.toLocaleString('fr-FR', { maximumFractionDigits: 2 })
+  return n.toLocaleString('fr-FR')
 }
 
 export function EuropeRegionMap({ customText }: { customText?: IndicatorCustomText | null }) {
@@ -386,6 +384,7 @@ export function EuropeRegionMap({ customText }: { customText?: IndicatorCustomTe
                       <p className="text-muted-foreground mt-1 text-xs">
                         {t('statistics.firstTimeApplicantsLabel')}
                         {effectiveYear ? ` in ${effectiveYear}` : ''}
+                        {' in Greece'}
                       </p>
                     </div>
                   )

--- a/client/src/components/Indicators/IndicatorsDataTable.tsx
+++ b/client/src/components/Indicators/IndicatorsDataTable.tsx
@@ -13,8 +13,8 @@ import { useTranslation } from 'react-i18next'
 
 const ELA_BLUE = '#1d4ed8'
 
-const fmtInt = (n: number) => n.toLocaleString('en-US')
-const fmtDec = (n: number) => n.toLocaleString('en-US', { maximumFractionDigits: 2 })
+const fmtInt = (n: number) => n.toLocaleString('fr-FR')
+const fmtDec = (n: number) => n.toLocaleString('fr-FR', { maximumFractionDigits: 2 })
 
 interface Props {
   data: MapIndicatorRecord[]

--- a/client/src/components/Indicators/KeyFiguresHeader.tsx
+++ b/client/src/components/Indicators/KeyFiguresHeader.tsx
@@ -3,7 +3,7 @@ import { StatCard } from '@/components/ui'
 import type { KeyFigureCard, KeyFiguresData } from '@/hooks/useKeyFigures'
 
 const fmt = (n: number | null) =>
-  n != null ? n.toLocaleString('en-US') : '—'
+  n != null ? n.toLocaleString('fr-FR') : '—'
 
 function KeyFigureStatCard({ card, isGr }: { card: KeyFigureCard; isGr: boolean }) {
   const label = isGr ? card.label_gr : card.label_en

--- a/client/src/components/Indicators/ProtectionDecisionsDetails.tsx
+++ b/client/src/components/Indicators/ProtectionDecisionsDetails.tsx
@@ -54,7 +54,7 @@ function TreeRow({
           </span>
         </span>
       </td>
-      <td className="px-4 py-2 text-right text-sm">{value.toLocaleString()}</td>
+      <td className="px-4 py-2 text-right text-sm">{value.toLocaleString('fr-FR')}</td>
       <td className="px-4 py-2 text-right text-sm text-gray-400">{pct}</td>
     </tr>
   )
@@ -228,7 +228,7 @@ function DecisionsContent({
                   <Cell key={entry.name} fill={entry.color} />
                 ))}
               </Pie>
-              <Tooltip formatter={(value) => (value != null ? Number(value).toLocaleString() : '')} />
+              <Tooltip formatter={(value) => (value != null ? Number(value).toLocaleString('fr-FR') : '')} />
             </PieChart>
           </ChartContainer>
           <div className="w-full space-y-2 px-2">
@@ -236,7 +236,7 @@ function DecisionsContent({
               <div key={d.name} className="flex items-center gap-2">
                 <div className="w-3 h-3 rounded-full flex-shrink-0" style={{ backgroundColor: d.color }} />
                 <span className="text-sm text-gray-700">{d.name}</span>
-                <span className="ml-auto text-sm font-semibold text-gray-800">{d.value.toLocaleString()}</span>
+                <span className="ml-auto text-sm font-semibold text-gray-800">{d.value.toLocaleString('fr-FR')}</span>
               </div>
             ))}
           </div>

--- a/client/src/components/Layout/StatisticLayoutPage.tsx
+++ b/client/src/components/Layout/StatisticLayoutPage.tsx
@@ -33,10 +33,10 @@ export const StatisticLayoutPage = () => {
     { label: (isGr ? asylumApplicationsInEurope?.title_gr : asylumApplicationsInEurope?.title_en) || t('statistics.euAsylumApplications'), to: 'AsylumApplicationsInEurope' },
     { label: (isGr ? asylumApplicationsInEuropeanUnion?.title_gr : asylumApplicationsInEuropeanUnion?.title_en) || t('statistics.euAsylumApplications'), to: 'AsylumApplicationsInEuropeanUnion' },
     { label: (isGr ? arrivalsInGreece?.title_gr : arrivalsInGreece?.title_en) || t('statistics.arrivalsGreece'), to: 'ArrivalsInGreece' },
+    { label: (isGr ? asylumSeekersCamps?.title_gr : asylumSeekersCamps?.title_en) || t('statistics.asylumSeekersCamps'), to: 'AsylumSeekersCamps' },
     { label: (isGr ? asylumApplicationsEvolutionInGreece?.title_gr : asylumApplicationsEvolutionInGreece?.title_en) || t('statistics.asylumEvolutionGreece'), to: 'AsylumApplicationsEvolutionInGreece' },
     { label: (isGr ? protectionGrantedVsRejected?.title_gr : protectionGrantedVsRejected?.title_en) || t('statistics.protectionDecisions'), to: 'ProtectionGrantedVsRejected' },
     { label: (isGr ? courtAsylumProcedures?.title_gr : courtAsylumProcedures?.title_en) || t('statistics.courtAsylumProcedures'), to: 'CourtAsylumProcedures' },
-    { label: (isGr ? asylumSeekersCamps?.title_gr : asylumSeekersCamps?.title_en) || t('statistics.asylumSeekersCamps'), to: 'AsylumSeekersCamps' },
     // {label: (isGr ? applicationsEvolutionGreece?.title_gr : applicationsEvolutionGreece?.title_en) || t('statistics.applicationsEvolutionGreece'), to: 'ApplicationsEvolutionGreece'},
     // {label: (isGr ? recognitionRates?.title_gr : recognitionRates?.title_en) || t('statistics.recognitionRates'), to: 'RecognitionRates'}
   ]

--- a/client/src/components/ui/chart.tsx
+++ b/client/src/components/ui/chart.tsx
@@ -167,7 +167,7 @@ function ChartTooltipContent({
                 {item.value !== undefined && (
                   <span className="font-mono font-medium tabular-nums">
                     {typeof item.value === 'number'
-                      ? item.value.toLocaleString()
+                      ? item.value.toLocaleString('fr-FR')
                       : item.value}
                   </span>
                 )}

--- a/client/src/hooks/useArrivalsGreece.ts
+++ b/client/src/hooks/useArrivalsGreece.ts
@@ -15,6 +15,7 @@ export interface ArrivalsGreeceRecord {
   leros: number
   kos: number
   chios: number
+  crete: number
   other_islands: number
 }
 
@@ -29,6 +30,7 @@ export interface ArrivalsGreeceYearly {
   leros: number
   kos: number
   chios: number
+  crete: number
   other_islands: number
 }
 
@@ -75,6 +77,8 @@ export function useArrivalsGreece() {
         leros: toNum(r.fields['Leros']),
         kos: toNum(r.fields['Kos']),
         chios: toNum(r.fields['Chios']),
+        crete: toNum(r.fields['Crete']),
+        // NB : le nom de colonne contient bien une espace — 'Other _islands'
         other_islands: toNum(r.fields['Other _islands']),
       }))
       setRecords(parsed)
@@ -108,6 +112,7 @@ export function aggregateByYear(records: ArrivalsGreeceRecord[]): ArrivalsGreece
       existing.leros += r.leros
       existing.kos += r.kos
       existing.chios += r.chios
+      existing.crete += r.crete
       existing.other_islands += r.other_islands
     }
     else {


### PR DESCRIPTION
## Format des nombres (le gros du diff)

Tous les nombres de la page Advocacy passent au format européen : espace comme séparateur de milliers, plus de virgule. `28,275` → `28 275`.

Deux incohérences préexistantes au passage :
- 8 endroits forçaient `en-US`, 20 autres suivaient la locale du navigateur — un visiteur français et un visiteur anglais ne voyaient donc pas la même chose sur la même page. C'est unifié sur `fr-FR`.
- L'indicateur *Asylum applications in EU Member States* avait sa propre fonction `fmtK()` qui affichait `69k`. Supprimée, le chiffre s'affiche en entier : `68 995`.

Précision : les axes Y des graphiques gardent volontairement leur format court (`250k`), c'est plus lisible sur un axe.

## Arrivées de Crète absentes de l'indicateur

La table Airtable a une colonne `Crete` remplie, mais le hook ne la lisait pas. Sur 2025 ça fait **15 406 arrivées non comptées, soit 36 % du total** (la page affichait 27 253 au lieu de 42 659). La Crète est le premier point d'entrée cette année-là, devant Evros.

La route est récente (0 en 2024), ce qui explique que ça soit passé inaperçu. Introduit dans `87eb96e`, simple oubli.

## Libellé « in Greece »

Le bloc de gauche de l'indicateur *Asylum applications in Europe* est câblé en dur sur la Grèce mais ne le disait nulle part. Il affiche maintenant « First-time asylum applications in 2024 in Greece ».

## Ordre des onglets

`Asylum seekers living in camps` passe en 4ᵉ position.

## À noter

La refonte de la carte en bulles proportionnelles a été sortie de cette PR, elle est dans #170.

## Vérifié

`vite build` OK.