### PR TITLE
feat(advocacy): carte à bulles pour les arrivées par point d'entrée

### DIFF
--- a/client/src/components/Indicators/ArrivalsGreeceDetails.tsx
+++ b/client/src/components/Indicators/ArrivalsGreeceDetails.tsx
@@ -13,31 +13,55 @@ import { Map as MapIcon, BarChart2 } from 'lucide-react'
 import { BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, Cell, ResponsiveContainer } from 'recharts'
 
 const PROTOMAP_KEY = import.meta.env.VITE_PROTOMAP_KEY as string
-const NAME_PROP = 'name'
 
-type RegionDef = {
+const SEA_COLOR = '#3b82f6'
+const LAND_COLOR = '#1e3a8a'
+
+// Un cercle par point d'entrée, posé sur l'île (ou sur le poste-frontière pour
+// Evros). Les données Airtable ne portent pas de coordonnées — contrairement aux
+// camps, où elles viennent de la base — donc on les fixe ici.
+// NB : MapLibre attend [lng, lat].
+// `other_islands` n'a volontairement pas de point : c'est un agrégat sans
+// localisation, il resterait arbitraire de le poser quelque part. Il n'apparaît
+// donc que dans le classement à droite.
+const ENTRY_POINTS: {
   label: string
+  coords: [number, number]
   getValue: (y: ArrivalsGreeceYearly) => number
   color: string
-}
+}[] = [
+  { label: 'Crete', coords: [24.81, 35.24], getValue: y => y.crete, color: SEA_COLOR },
+  { label: 'Lesvos', coords: [26.27, 39.22], getValue: y => y.lesvos, color: SEA_COLOR },
+  { label: 'Chios', coords: [26.00, 38.40], getValue: y => y.chios, color: SEA_COLOR },
+  { label: 'Samos', coords: [26.83, 37.75], getValue: y => y.samos, color: SEA_COLOR },
+  { label: 'Leros', coords: [26.85, 37.15], getValue: y => y.leros, color: SEA_COLOR },
+  { label: 'Kos', coords: [27.20, 36.85], getValue: y => y.kos, color: SEA_COLOR },
+  { label: 'Evros', coords: [26.50, 41.35], getValue: y => y.evros, color: LAND_COLOR },
+]
 
-const REGION_DEFS: Record<string, RegionDef> = {
-  'Anatoliki Makedonia kai Thraki': {
-    label: 'Evros',
-    getValue: y => y.evros,
-    color: '#1e3a8a',
-  },
-  'Voreio Aigaio': {
-    label: 'Voreio Aigaio',
-    getValue: y => y.lesvos + y.samos + y.chios,
-    color: '#3b82f6',
-  },
-  'Notio Aigaio': {
-    label: 'Notio Aigaio',
-    getValue: y => y.kos + y.leros + y.other_islands,
-    color: '#6366f1',
-  },
-}
+const buildPointsGeoJSON = (y: ArrivalsGreeceYearly | null) => ({
+  type: 'FeatureCollection' as const,
+  features: (y ? ENTRY_POINTS : [])
+    .map(p => ({ p, value: p.getValue(y!) }))
+    .filter(({ value }) => value > 0)
+    .map(({ p, value }) => ({
+      type: 'Feature' as const,
+      properties: { label: p.label, value, color: p.color },
+      geometry: { type: 'Point' as const, coordinates: p.coords },
+    })),
+})
+
+// Rayon en racine carrée de la valeur : c'est l'AIRE du cercle qui doit être
+// proportionnelle au volume, sinon l'écart est visuellement surinterprété.
+const radiusExpression = (maxValue: number): any => [
+  'interpolate',
+  ['linear'],
+  ['sqrt', ['get', 'value']],
+  0,
+  3,
+  Math.sqrt(Math.max(maxValue, 1)),
+  32,
+]
 
 const SEA_ISLANDS: { key: keyof ArrivalsGreeceYearly, label: string, color: string }[] = [
   { key: 'crete', label: 'Crete', color: '#4f46e5' },
@@ -49,17 +73,13 @@ const SEA_ISLANDS: { key: keyof ArrivalsGreeceYearly, label: string, color: stri
   { key: 'leros', label: 'Leros', color: '#c7d2fe' },
 ]
 
-function applyMapData(map: maplibregl.Map, regionValues: Record<string, number>) {
-  const colorExpr: any = [
-    'match',
-    ['get', NAME_PROP],
-    ...Object.entries(regionValues).flatMap(([name]) => [
-      name,
-      REGION_DEFS[name]?.color ?? '#e5e7eb',
-    ]),
-    '#e5e7eb',
-  ]
-  map.setPaintProperty('region-fill', 'fill-color', colorExpr)
+function applyMapData(map: maplibregl.Map, yearData: ArrivalsGreeceYearly | null) {
+  const source = map.getSource('points') as maplibregl.GeoJSONSource | undefined
+  if (!source) return
+  const data = buildPointsGeoJSON(yearData)
+  source.setData(data as any)
+  const max = Math.max(...data.features.map(f => f.properties.value), 1)
+  map.setPaintProperty('points-circle', 'circle-radius', radiusExpression(max))
 }
 
 export function ArrivalsGreeceDetails({
@@ -80,7 +100,7 @@ export function ArrivalsGreeceDetails({
 
   const containerRef = useRef<HTMLDivElement>(null)
   const mapRef = useRef<maplibregl.Map | null>(null)
-  const regionValuesRef = useRef<Record<string, number>>({})
+  const yearDataRef = useRef<ArrivalsGreeceYearly | null>(null)
 
   const yearly = useMemo(() => aggregateByYear(records), [records])
   const years = useMemo(() => yearly.map(r => r.year).sort((a, b) => b - a), [yearly])
@@ -92,16 +112,7 @@ export function ArrivalsGreeceDetails({
     [yearly, effectiveYear],
   )
 
-  const regionValues = useMemo(() => {
-    if (!yearData) return {}
-    return Object.fromEntries(
-      Object.entries(REGION_DEFS)
-        .map(([name, def]) => [name, def.getValue(yearData)])
-        .filter(([, v]) => (v as number) > 0),
-    ) as Record<string, number>
-  }, [yearData])
-
-  regionValuesRef.current = regionValues
+  yearDataRef.current = yearData
 
   const seaRanking = useMemo(() => {
     if (!yearData) return []
@@ -174,6 +185,9 @@ export function ArrivalsGreeceDetails({
         }
       }
 
+      // Les régions ne portent plus la donnée : elles servent de fond
+      // géographique. Peindre une périphérie entière (le Dodécanèse, ~50 îles)
+      // pour quelques points de débarquement surinterprétait la géographie.
       map.addLayer({
         id: 'region-fill',
         type: 'fill',
@@ -186,33 +200,37 @@ export function ArrivalsGreeceDetails({
         source: 'greece',
         paint: { 'line-color': '#ffffff', 'line-width': 0.8, 'line-opacity': 0.9 },
       }, firstSymbolId)
+
+      map.addSource('points', { type: 'geojson', data: buildPointsGeoJSON(yearDataRef.current) as any })
       map.addLayer({
-        id: 'region-hover',
-        type: 'fill',
-        source: 'greece',
-        paint: { 'fill-color': '#ffffff', 'fill-opacity': 0 },
-      }, firstSymbolId)
+        id: 'points-circle',
+        type: 'circle',
+        source: 'points',
+        paint: {
+          'circle-radius': radiusExpression(1),
+          'circle-color': ['get', 'color'],
+          'circle-opacity': 0.75,
+          'circle-stroke-width': 1.5,
+          'circle-stroke-color': '#ffffff',
+        },
+      })
 
-      applyMapData(map, regionValuesRef.current)
+      applyMapData(map, yearDataRef.current)
 
-      map.on('mousemove', 'region-hover', (e) => {
+      map.on('mousemove', 'points-circle', (e) => {
         if (!e.features?.length) return
         map.getCanvas().style.cursor = 'pointer'
-        const name = e.features[0].properties?.[NAME_PROP] as string | undefined
-        if (!name) return
-        const def = REGION_DEFS[name]
-        const value = regionValuesRef.current[name]
-        if (!def || value == null) return
+        const { label, value } = e.features[0].properties as { label: string, value: number }
         popup
           .setHTML(`
-            <div style="font-size:12px;font-weight:600;margin-bottom:4px">${def.label}</div>
-            <div style="font-size:12px">&#8226; ${value.toLocaleString()}</div>
+            <div style="font-size:12px;font-weight:600;margin-bottom:4px">${label}</div>
+            <div style="font-size:12px">&#8226; ${Number(value).toLocaleString('fr-FR')}</div>
           `)
           .setLngLat(e.lngLat)
           .addTo(map)
       })
 
-      map.on('mouseleave', 'region-hover', () => {
+      map.on('mouseleave', 'points-circle', () => {
         map.getCanvas().style.cursor = ''
         popup.remove()
       })
@@ -229,13 +247,13 @@ export function ArrivalsGreeceDetails({
   useEffect(() => {
     const map = mapRef.current
     if (!map) return
-    const apply = () => applyMapData(map, regionValues)
+    const apply = () => applyMapData(map, yearData)
     if (map.isStyleLoaded()) apply()
     else {
       map.once('load', apply)
       return () => { map.off('load', apply) }
     }
-  }, [regionValues])
+  }, [yearData])
 
   // When switching back to map view, the container was hidden (display:none) so
   // MapLibre doesn't know its real size — resize to fix blank canvas.
@@ -339,7 +357,7 @@ export function ArrivalsGreeceDetails({
                         />
                       </div>
                       <span className="w-12 flex-shrink-0 text-right text-xs text-gray-700 tabular-nums">
-                        {value.toLocaleString()}
+                        {value.toLocaleString('fr-FR')}
                       </span>
                     </div>
                   </div>
@@ -359,7 +377,7 @@ export function ArrivalsGreeceDetails({
                     />
                   </div>
                   <span className="w-12 flex-shrink-0 text-right text-xs text-gray-700 tabular-nums">
-                    {evrosValue.toLocaleString()}
+                    {evrosValue.toLocaleString('fr-FR')}
                   </span>
                 </div>
               </div>
@@ -378,7 +396,7 @@ export function ArrivalsGreeceDetails({
                   <XAxis dataKey="label" tick={{ fontSize: 11 }} angle={-35} textAnchor="end" interval={0} />
                   <YAxis tickFormatter={v => v >= 1000 ? `${(v / 1000).toFixed(0)}K` : String(v)} tick={{ fontSize: 11 }} />
                   <Tooltip
-                    formatter={(value) => [Number(value).toLocaleString(), t('statistics.arrivals')]}
+                    formatter={(value) => [Number(value).toLocaleString('fr-FR'), t('statistics.arrivals')]}
                     cursor={{ fill: 'rgba(0,0,0,0.04)' }}
                   />
                   <Bar dataKey="value" radius={[3, 3, 0, 0]}>

--- a/client/src/components/Indicators/ArrivalsGreeceDetails.tsx
+++ b/client/src/components/Indicators/ArrivalsGreeceDetails.tsx
@@ -14,8 +14,18 @@ import { BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, Cell, ResponsiveCo
 
 const PROTOMAP_KEY = import.meta.env.VITE_PROTOMAP_KEY as string
 
-const SEA_COLOR = '#3b82f6'
-const LAND_COLOR = '#1e3a8a'
+// Source unique des couleurs : les bulles de la carte et les barres du
+// classement lisent ici, sinon les deux représentations divergent.
+const COLORS: Record<string, string> = {
+  crete: '#4f46e5',
+  lesvos: '#3b82f6',
+  chios: '#4f8ff7',
+  samos: '#6366f1',
+  other_islands: '#818cf8',
+  kos: '#a5b4fc',
+  leros: '#c7d2fe',
+  evros: '#1e3a8a',
+}
 
 // Un cercle par point d'entrée, posé sur l'île (ou sur le poste-frontière pour
 // Evros). Les données Airtable ne portent pas de coordonnées — contrairement aux
@@ -25,28 +35,27 @@ const LAND_COLOR = '#1e3a8a'
 // localisation, il resterait arbitraire de le poser quelque part. Il n'apparaît
 // donc que dans le classement à droite.
 const ENTRY_POINTS: {
+  key: keyof ArrivalsGreeceYearly
   label: string
   coords: [number, number]
-  getValue: (y: ArrivalsGreeceYearly) => number
-  color: string
 }[] = [
-  { label: 'Crete', coords: [24.81, 35.24], getValue: y => y.crete, color: SEA_COLOR },
-  { label: 'Lesvos', coords: [26.27, 39.22], getValue: y => y.lesvos, color: SEA_COLOR },
-  { label: 'Chios', coords: [26.00, 38.40], getValue: y => y.chios, color: SEA_COLOR },
-  { label: 'Samos', coords: [26.83, 37.75], getValue: y => y.samos, color: SEA_COLOR },
-  { label: 'Leros', coords: [26.85, 37.15], getValue: y => y.leros, color: SEA_COLOR },
-  { label: 'Kos', coords: [27.20, 36.85], getValue: y => y.kos, color: SEA_COLOR },
-  { label: 'Evros', coords: [26.50, 41.35], getValue: y => y.evros, color: LAND_COLOR },
+  { key: 'crete', label: 'Crete', coords: [24.81, 35.24] },
+  { key: 'lesvos', label: 'Lesvos', coords: [26.27, 39.22] },
+  { key: 'chios', label: 'Chios', coords: [26.00, 38.40] },
+  { key: 'samos', label: 'Samos', coords: [26.83, 37.75] },
+  { key: 'leros', label: 'Leros', coords: [26.85, 37.15] },
+  { key: 'kos', label: 'Kos', coords: [27.20, 36.85] },
+  { key: 'evros', label: 'Evros', coords: [26.50, 41.35] },
 ]
 
 const buildPointsGeoJSON = (y: ArrivalsGreeceYearly | null) => ({
   type: 'FeatureCollection' as const,
   features: (y ? ENTRY_POINTS : [])
-    .map(p => ({ p, value: p.getValue(y!) }))
+    .map(p => ({ p, value: y![p.key] as number }))
     .filter(({ value }) => value > 0)
     .map(({ p, value }) => ({
       type: 'Feature' as const,
-      properties: { label: p.label, value, color: p.color },
+      properties: { label: p.label, value, color: COLORS[p.key] },
       geometry: { type: 'Point' as const, coordinates: p.coords },
     })),
 })
@@ -63,14 +72,14 @@ const radiusExpression = (maxValue: number): any => [
   32,
 ]
 
-const SEA_ISLANDS: { key: keyof ArrivalsGreeceYearly, label: string, color: string }[] = [
-  { key: 'crete', label: 'Crete', color: '#4f46e5' },
-  { key: 'lesvos', label: 'Lesvos', color: '#3b82f6' },
-  { key: 'chios', label: 'Chios', color: '#4f8ff7' },
-  { key: 'samos', label: 'Samos', color: '#6366f1' },
-  { key: 'other_islands', label: 'Other islands', color: '#818cf8' },
-  { key: 'kos', label: 'Kos', color: '#a5b4fc' },
-  { key: 'leros', label: 'Leros', color: '#c7d2fe' },
+const SEA_ISLANDS: { key: keyof ArrivalsGreeceYearly, label: string }[] = [
+  { key: 'crete', label: 'Crete' },
+  { key: 'lesvos', label: 'Lesvos' },
+  { key: 'chios', label: 'Chios' },
+  { key: 'samos', label: 'Samos' },
+  { key: 'other_islands', label: 'Other islands' },
+  { key: 'kos', label: 'Kos' },
+  { key: 'leros', label: 'Leros' },
 ]
 
 function applyMapData(map: maplibregl.Map, yearData: ArrivalsGreeceYearly | null) {
@@ -117,7 +126,7 @@ export function ArrivalsGreeceDetails({
   const seaRanking = useMemo(() => {
     if (!yearData) return []
     return SEA_ISLANDS
-      .map(({ key, label, color }) => ({ label, color, value: yearData[key] as number }))
+      .map(({ key, label }) => ({ label, color: COLORS[key], value: yearData[key] as number }))
       .filter(d => d.value > 0)
       .sort((a, b) => b.value - a.value)
   }, [yearData])
@@ -127,7 +136,7 @@ export function ArrivalsGreeceDetails({
 
   const barData = useMemo(() => [
     ...seaRanking,
-    ...(evrosValue > 0 ? [{ label: 'Evros', value: evrosValue, color: '#1e3a8a' }] : []),
+    ...(evrosValue > 0 ? [{ label: 'Evros', value: evrosValue, color: COLORS.evros }] : []),
   ], [seaRanking, evrosValue])
 
   const title = (isGr ? customText?.title_gr : customText?.title_en) || t('statistics.arrivalsGreece')
@@ -340,17 +349,17 @@ export function ArrivalsGreeceDetails({
 
             {/* Ranking panel */}
             <div className="w-64 flex-shrink-0 overflow-y-auto rounded-lg border border-gray-200 p-4">
-              <h3 className="mb-4 text-sm font-bold text-gray-900">{t('statistics.rankingLocations')}</h3>
+              <h3 className="mb-3 text-sm font-bold text-gray-900">{t('statistics.rankingLocations')}</h3>
 
-              <h4 className="mb-3 text-xs font-semibold tracking-wide text-gray-500 uppercase">
+              <h4 className="mb-1.5 text-xs font-semibold tracking-wide text-gray-500 uppercase">
                 {t('statistics.seaArrivals')}
               </h4>
-              <div className="mb-5 space-y-2.5">
+              <div className="mb-3 space-y-1.5">
                 {seaRanking.map(({ label, color, value }) => (
                   <div key={label}>
                     <span className="text-xs text-gray-700">{label}</span>
                     <div className="mt-0.5 flex items-center gap-2">
-                      <div className="h-5 flex-1 overflow-hidden rounded-sm bg-gray-100">
+                      <div className="h-4 flex-1 overflow-hidden rounded-sm bg-gray-100">
                         <div
                           className="h-full rounded-sm"
                           style={{ width: `${(value / maxRankValue) * 100}%`, backgroundColor: color }}
@@ -364,16 +373,16 @@ export function ArrivalsGreeceDetails({
                 ))}
               </div>
 
-              <h4 className="mb-3 text-xs font-semibold tracking-wide text-gray-500 uppercase">
+              <h4 className="mb-1.5 text-xs font-semibold tracking-wide text-gray-500 uppercase">
                 {t('statistics.landArrivals')}
               </h4>
+              {/* pas de libellé « Evros » ici : le titre de section le porte déjà */}
               <div>
-                <span className="text-xs text-gray-700">Evros</span>
-                <div className="mt-0.5 flex items-center gap-2">
-                  <div className="h-5 flex-1 overflow-hidden rounded-sm bg-gray-100">
+                <div className="flex items-center gap-2">
+                  <div className="h-4 flex-1 overflow-hidden rounded-sm bg-gray-100">
                     <div
-                      className="h-full rounded-sm bg-blue-900"
-                      style={{ width: `${(evrosValue / maxRankValue) * 100}%` }}
+                      className="h-full rounded-sm"
+                      style={{ width: `${(evrosValue / maxRankValue) * 100}%`, backgroundColor: COLORS.evros }}
                     />
                   </div>
                   <span className="w-12 flex-shrink-0 text-right text-xs text-gray-700 tabular-nums">


### PR DESCRIPTION
> Empilée sur #169 — la base de cette PR est `fix/advocacy-number-format`, pas `main`. Le diff affiché ici ne contient donc que la carte. À merger après #169.

## Problème

Sur l'indicateur *Arrivals in Greece by entry point*, la carte colorait des zones administratives issues du GeoJSON. Deux soucis :

- les zones colorées ne correspondaient pas aux îles réellement concernées ;
- les libellés venaient du GeoJSON, donc s'affichaient en grec même sur l'interface anglaise.

## Correction

Une bulle par point d'entrée, posée sur l'île (ou sur le poste-frontière pour Evros) : Lesvos, Chios, Samos, Leros, Kos, Crète et Evros. C'est le même principe que l'indicateur *Asylum seekers in Greece*, qui utilisait déjà des points.

Les données Airtable ne portent pas de coordonnées — contrairement aux camps, où elles viennent de la base — donc elles sont fixées dans le fichier, avec un commentaire qui l'explique.

**Le rayon suit la racine carrée de la valeur.** C'est l'aire du cercle qui doit être proportionnelle au volume : à rayon proportionnel, un chiffre 4× plus grand donnerait un disque 16× plus gros, ce qui surinterprète l'écart.

## Limite assumée

`Other islands` n'a pas de bulle : c'est un agrégat sans localisation, le poser quelque part serait arbitraire. Il reste dans le classement à droite. **Conséquence : la somme des bulles ne fait pas le total.** Si ça pose problème, une note sous la carte serait le plus simple.

## Vérifié

`vite build` OK. Contrôlé visuellement en local : les 7 bulles sont bien positionnées, les infobulles affichent le nom en anglais et le nombre au format européen (« Crete • 5 520 »), les tailles suivent le classement.