### PR TITLE
fix: indicateur Asylum applications in EU Member States

### DIFF
--- a/client/src/components/Indicators/EuropeRegionMap.tsx
+++ b/client/src/components/Indicators/EuropeRegionMap.tsx
@@ -84,6 +84,7 @@ export function EuropeRegionMap({ customText }: { customText?: IndicatorCustomTe
   const containerRef = useRef<HTMLDivElement>(null)
   const mapRef = useRef<maplibregl.Map | null>(null)
 
+  const mapLoadedRef = useRef(false)
   const popupRootRef = useRef<ReturnType<typeof createRoot> | null>(null)
   const dataByCodeRef = useRef<Record<string, MapIndicatorRecord>>({})
   const perCapitaRef = useRef(false)
@@ -250,10 +251,12 @@ export function EuropeRegionMap({ customText }: { customText?: IndicatorCustomTe
         popup.remove()
       })
 
+      mapLoadedRef.current = true
       applyMapData(map, yearRecordsRef.current, perCapitaRef.current, thresholdsRef.current)
     })
 
     return () => {
+      mapLoadedRef.current = false
       popupRootRef.current?.unmount()
       popup.remove()
       map.remove()
@@ -264,16 +267,10 @@ export function EuropeRegionMap({ customText }: { customText?: IndicatorCustomTe
   // ── Re-apply whenever data / year / perCapita changes ───────────────────────
   useEffect(() => {
     const map = mapRef.current
-    if (!map) return
-    const apply = () => applyMapData(map, yearRecords, perCapita, thresholds)
-    if (map.isStyleLoaded()) {
-      apply()
-    }
-    else {
-      // Map not ready yet — apply as soon as it is
-      map.once('load', apply)
-      return () => { map.off('load', apply) }
-    }
+    // Before `load` fires, the load handler applies the latest refs itself. Waiting
+    // on `once('load')` here would deadlock: the event may already have fired.
+    if (!map || !mapLoadedRef.current) return
+    applyMapData(map, yearRecords, perCapita, thresholds)
   }, [yearRecords, perCapita, thresholds])
 
   const title = (isGr ? customText?.title_gr : customText?.title_en) || t('statistics.numberOfApplicationsEurope')
@@ -446,7 +443,7 @@ export function EuropeRegionMap({ customText }: { customText?: IndicatorCustomTe
         {/* Card footer — source & last updated */}
         {(customText?.source || customText?.last_updated_on) && (
           <div className="space-y-1 border-t border-gray-100 bg-gray-50/60 px-6 py-3 text-xs text-gray-500">
-            <div className="flex flex-wrap items-center gap-x-6 gap-y-1">
+            <div className="flex flex-wrap items-center justify-between gap-x-6 gap-y-1">
               {customText.source && (
                 <span>
                   <span className="font-medium text-gray-600">

--- a/client/src/components/Indicators/IndicatorsDataTable.tsx
+++ b/client/src/components/Indicators/IndicatorsDataTable.tsx
@@ -36,8 +36,6 @@ export function IndicatorsDataTable({ data, perCapita }: Props) {
   const perCapitaColumns: ColumnDef<MapIndicatorRecord>[] = useMemo(() => [
     { accessorKey: 'name_country', header: t('statistics.country') },
     { accessorKey: 'total_applicants_per_capita', header: t('statistics.totalPerCapita'), cell: ({ getValue }) => fmtDec(getValue<number>()) },
-    { accessorKey: 'first_time_applicants_per_capita', header: t('statistics.firstTimePerCapitaShort'), cell: ({ getValue }) => fmtDec(getValue<number>()) },
-    { accessorKey: 'subsequent_applicants_per_capita', header: t('statistics.subsequentPerCapita'), cell: ({ getValue }) => fmtDec(getValue<number>()) },
   ], [t])
 
   const columns = useMemo(


### PR DESCRIPTION
Trois correctifs sur l'onglet EU Member States.

**Carte grise au chargement.** Les dégradés de bleu n'apparaissaient qu'après un changement d'année. L'effet attendait `once('load')` lorsque `isStyleLoaded()` renvoyait false, mais l'événement avait déjà pu être émis — l'attente ne se résolvait jamais. Remplacé par un ref posé dans le handler de load.

**Tableau PER CAPITA.** Ne garde que `Country` et `Total per capita`.

**Pied de carte.** `Last updated` aligné à droite, comme les autres onglets.

Les clés i18n `firstTimePerCapitaShort` et `subsequentPerCapita` deviennent inutilisées, laissées en place pour ne pas interférer avec les traductions en cours.