### PR TITLE
fix: Advocacy general UI — cartes d'indicateur à la largeur de la page

### DIFF
--- a/client/src/components/Indicators/ApplicationsEvolutionGreeceDetails.tsx
+++ b/client/src/components/Indicators/ApplicationsEvolutionGreeceDetails.tsx
@@ -51,7 +51,7 @@ export function ApplicationsEvolutionGreeceDetails({
   if (records.length === 0) return <p className="text-muted-foreground text-sm p-6">{t('statistics.noData')}</p>
 
   return (
-    <div className="mx-auto max-w-5xl my-6">
+    <div className="mx-auto my-6">
       <div className="overflow-hidden rounded-xl border border-gray-200 bg-white shadow-sm">
 
         {/* Card header */}

--- a/client/src/components/Indicators/ArrivalsGreeceDetails.tsx
+++ b/client/src/components/Indicators/ArrivalsGreeceDetails.tsx
@@ -274,7 +274,7 @@ export function ArrivalsGreeceDetails({
   }, [view])
 
   return (
-    <div className="mx-auto my-6 max-w-5xl">
+    <div className="mx-auto my-6">
       <div className="overflow-hidden rounded-xl border border-gray-200 bg-white shadow-sm">
 
         {/* Card header */}

--- a/client/src/components/Indicators/AsylumApplicationsDetails.tsx
+++ b/client/src/components/Indicators/AsylumApplicationsDetails.tsx
@@ -119,7 +119,7 @@ export function AsylumApplicationsDetails({
   const totalFirstTimeApplicants = chartData.reduce((sum, d) => sum + d.first_time_applicants, 0)
 
   return (
-    <div className="mx-auto max-w-5xl my-6">
+    <div className="mx-auto my-6">
       <div className="overflow-hidden rounded-xl border border-gray-200 bg-white shadow-sm">
 
         {/* Card header */}

--- a/client/src/components/Indicators/AsylumApplicationsEvolutionInGreeceDetails.tsx
+++ b/client/src/components/Indicators/AsylumApplicationsEvolutionInGreeceDetails.tsx
@@ -262,7 +262,7 @@ export function AsylumApplicationsEvolutionInGreeceDetails({
   const information = isGr ? customText?.information_gr : customText?.information_en
 
   return (
-    <div className="mx-auto max-w-5xl my-6">
+    <div className="mx-auto my-6">
       <div className="overflow-hidden rounded-xl border border-gray-200 bg-white shadow-sm">
 
         {/* Card header */}

--- a/client/src/components/Indicators/AsylumSeekersCampsDetails.tsx
+++ b/client/src/components/Indicators/AsylumSeekersCampsDetails.tsx
@@ -320,7 +320,7 @@ export function AsylumSeekersCampsDetails({
   if (records.length === 0) return <p className="text-muted-foreground text-sm p-6">{t('statistics.noData')}</p>
 
   return (
-    <div className="mx-auto max-w-5xl my-6">
+    <div className="mx-auto my-6">
       <div className="overflow-hidden rounded-xl border border-gray-200 bg-white shadow-sm">
 
         {/* Card header */}

--- a/client/src/components/Indicators/CourtAsylumProceduresDetails.tsx
+++ b/client/src/components/Indicators/CourtAsylumProceduresDetails.tsx
@@ -371,7 +371,7 @@ export function CourtAsylumProceduresDetails({
   const information = isGr ? customText?.information_gr : customText?.information_en
 
   return (
-    <div className="mx-auto my-6 max-w-5xl space-y-8">
+    <div className="mx-auto my-6 space-y-8">
       {/* Card 1: header + annulments table/donut */}
       <div className="overflow-hidden rounded-xl border border-gray-200 bg-white shadow-sm">
         <div className="border-b border-gray-100 bg-gray-50/60 px-6 py-5">

--- a/client/src/components/Indicators/EuropeRegionMap.tsx
+++ b/client/src/components/Indicators/EuropeRegionMap.tsx
@@ -283,7 +283,7 @@ export function EuropeRegionMap({ customText }: { customText?: IndicatorCustomTe
   const information = isGr ? customText?.information_gr : customText?.information_en
 
   return (
-    <div className="mx-auto my-6 max-w-5xl">
+    <div className="mx-auto my-6">
       <div className="overflow-hidden rounded-xl border border-gray-200 bg-white shadow-sm">
 
         {/* Card header */}

--- a/client/src/components/Indicators/MethodologySection.tsx
+++ b/client/src/components/Indicators/MethodologySection.tsx
@@ -20,7 +20,7 @@ export function MethodologySection({ customText }: { customText?: IndicatorCusto
   const displayText = expanded ? information : explanatoryText
 
   return (
-    <div className="mx-auto my-10 max-w-5xl">
+    <div className="mx-auto my-10">
       <div className="relative overflow-hidden rounded-xl border border-[#C4B5E3] bg-white p-8">
         <img
           src={elaAvatar}

--- a/client/src/components/Indicators/ProtectionDecisionsDetails.tsx
+++ b/client/src/components/Indicators/ProtectionDecisionsDetails.tsx
@@ -293,7 +293,7 @@ export function ProtectionDecisionsDetails({
   if (error) return <ErrorMessage message={error} onRetry={() => window.location.reload()} />
 
   return (<Tabs.Root className="TabsRoot" defaultValue="tab1">
-    <div className="mx-auto max-w-5xl my-6">
+    <div className="mx-auto my-6">
       <div className="overflow-hidden rounded-xl border border-gray-200 bg-white shadow-sm">
 
         {/* Card header */}

--- a/client/src/components/Indicators/RecognitionRatesDetails.tsx
+++ b/client/src/components/Indicators/RecognitionRatesDetails.tsx
@@ -172,7 +172,7 @@ export function RecognitionRatesDetails({
   if (records.length === 0) return <p className="text-muted-foreground text-sm p-6">{t('statistics.noData')}</p>
 
   return (
-    <div className="mx-auto max-w-5xl my-6">
+    <div className="mx-auto my-6">
       <div className="overflow-hidden rounded-xl border border-gray-200 bg-white shadow-sm">
 
         {/* Card header */}


### PR DESCRIPTION
Les cartes d'indicateur étaient en `max-w-5xl` (1024 px) dans un conteneur `max-w-315` (1260 px) : 236 px plus étroites que le bandeau, les chiffres clés et les onglets au-dessus.

`max-w-5xl` est une valeur Tailwind par défaut, `max-w-315` le gabarit du projet — l'écart semble venir de là, pas d'un choix de design.

Contrainte retirée sur les 10 composants concernés, une ligne chacun. Les panneaux latéraux restent en largeur fixe (`w-64` / 240 px), le gain va donc aux cartes, tableaux et graphiques.

Vérifié avec `npm run build` (exit 0) et validé visuellement sur les onglets.