### PR TITLE
feat: refonte de la navigation des indicateurs

### DIFF
--- a/client/src/components/Indicators/KeyFiguresBand.tsx
+++ b/client/src/components/Indicators/KeyFiguresBand.tsx
@@ -1,0 +1,95 @@
+import { useTranslation } from 'react-i18next'
+import type { KeyFigureCard, KeyFiguresData } from '@/hooks/useKeyFigures'
+import { NAV_COLORS } from '@/components/Layout/navTokens'
+
+const fmt = (n: number | null) =>
+  // Espace fine insécable comme séparateur de milliers, conformément à la maquette.
+  n != null ? n.toLocaleString('fr-FR').replace(/ | | /g, ' ') : '—'
+
+// Airtable ne porte pas la période dans un champ dédié : elle est incluse dans le
+// libellé (« First time applicants in Europe 2015-2025 »). On la détache pour la
+// composer séparément, et on rend le libellé entier si le motif est absent.
+const PERIOD_RE = /\s*(?:in\s+)?(\d{4}\s*[–-]\s*\d{4}|\d{4})\s*$/i
+
+function splitPeriod(label: string): { label: string, period: string } {
+  const m = PERIOD_RE.exec(label)
+  if (!m) return { label: label.trim(), period: '' }
+  return { label: label.slice(0, m.index).trim(), period: m[1].replace(/\s/g, '') }
+}
+
+function Cell({ card, isGr, bordered }: { card: KeyFigureCard, isGr: boolean, bordered: boolean }) {
+  const { label, period } = splitPeriod(isGr ? card.label_gr : card.label_en)
+  return (
+    <div
+      className={bordered ? 'pl-7 md:border-l' : ''}
+      style={bordered ? { borderColor: 'rgba(255,255,255,.16)' } : undefined}
+    >
+      <div
+        className="text-[32px] leading-none font-bold tracking-[-0.02em] text-white tabular-nums"
+      >
+        {fmt(card.value)}
+      </div>
+      {/* min-height réserve deux lignes : sans elle les quatre valeurs ne partagent
+          plus la même ligne de base dès qu'un libellé passe sur deux lignes. */}
+      <div
+        className="mt-2.5 text-xs leading-[1.45] font-medium"
+        style={{ color: NAV_COLORS.mutedOnNavy, minHeight: '2.6em' }}
+      >
+        {label}
+      </div>
+      {period && (
+        <div
+          className="text-[10.5px] leading-none font-bold tracking-[0.1em] uppercase"
+          style={{ color: NAV_COLORS.orangeLight }}
+        >
+          {period}
+        </div>
+      )}
+    </div>
+  )
+}
+
+export function KeyFiguresBand({ data }: { data: KeyFiguresData }) {
+  const { i18n } = useTranslation()
+  const isGr = i18n.language === 'el'
+  const title = isGr ? data.title_gr : data.title_en
+  const subtitle = isGr ? data.subtitle_gr : data.subtitle_en
+
+  const cards = [data.arrivalsEurope, data.arrivalsGreece, data.applicationsGreece, data.successfulDecisions]
+
+  return (
+    <div
+      className="relative left-1/2 -ml-[50vw] w-screen px-6 py-9 md:px-12 md:py-10"
+      style={{ backgroundColor: NAV_COLORS.navy }}
+    >
+      <div className="mx-auto w-full xl:max-w-315">
+        {title && (
+          <div className="mb-8 text-center">
+            <h2 className="font-gotham text-[28px] leading-[1.15] font-extrabold tracking-[0.01em] text-white uppercase md:text-[32px]">
+              {title}
+            </h2>
+            <div
+              className="mx-auto mt-4 h-[5px] w-[88px] rounded-[3px]"
+              style={{ backgroundColor: NAV_COLORS.orange }}
+            />
+          </div>
+        )}
+
+        {subtitle && (
+          <p
+            className="font-montserrat mx-auto mb-8 max-w-3xl text-center text-sm leading-relaxed whitespace-pre-line"
+            style={{ color: NAV_COLORS.mutedOnNavy }}
+          >
+            {subtitle}
+          </p>
+        )}
+
+        <div className="font-montserrat grid grid-cols-2 items-start gap-7 md:grid-cols-4">
+          {cards.map((card, i) => (
+            <Cell key={i} card={card} isGr={isGr} bordered={i > 0} />
+          ))}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/client/src/components/Indicators/KeyFiguresBand.tsx
+++ b/client/src/components/Indicators/KeyFiguresBand.tsx
@@ -20,8 +20,10 @@ function splitPeriod(label: string): { label: string, period: string } {
 function Cell({ card, isGr, bordered }: { card: KeyFigureCard, isGr: boolean, bordered: boolean }) {
   const { label, period } = splitPeriod(isGr ? card.label_gr : card.label_en)
   return (
+    // Padding symétrique et non seulement à gauche : avec un contenu centré, une
+    // marge d'un seul côté décalerait visuellement la colonne par rapport au trait.
     <div
-      className={bordered ? 'pl-7 md:border-l' : ''}
+      className={`px-3 text-center ${bordered ? 'md:border-l' : ''}`}
       style={bordered ? { borderColor: 'rgba(255,255,255,.16)' } : undefined}
     >
       <div

--- a/client/src/components/Layout/IndicatorNav.tsx
+++ b/client/src/components/Layout/IndicatorNav.tsx
@@ -1,0 +1,106 @@
+import { useMemo } from 'react'
+import { useNavigate, useLocation } from 'react-router-dom'
+import { NAV_COLORS, NAV_TRANSITION } from './navTokens'
+
+export interface IndicatorItem {
+  label: string
+  to: string
+  /** Clé de groupe, traduite à l'affichage. Les groupes sont déduits dans l'ordre
+   *  de la liste : ajouter un indicateur ne demande pas de toucher à la nav. */
+  group: string
+}
+
+export function IndicatorNav({
+  items,
+  groupLabel,
+}: {
+  items: IndicatorItem[]
+  groupLabel: (group: string) => string
+}) {
+  const navigate = useNavigate()
+  const location = useLocation()
+
+  // Ordre des groupes = ordre d'apparition dans `items`, pas alphabétique.
+  const groups = useMemo(() => {
+    const map = new Map<string, IndicatorItem[]>()
+    for (const item of items) {
+      if (!map.has(item.group)) map.set(item.group, [])
+      map.get(item.group)!.push(item)
+    }
+    return map
+  }, [items])
+
+  // Le groupe actif se déduit de l'URL, non d'un état local : sans ça un lien
+  // profond ou un retour arrière ouvrirait le mauvais groupe.
+  const activeItem = items.find(i => location.pathname.endsWith(`/${i.to}`))
+  const activeGroup = activeItem?.group ?? items[0]?.group ?? ''
+  const pills = groups.get(activeGroup) ?? []
+
+  const go = (to: string) => navigate({ pathname: to, search: location.search })
+
+  return (
+    <div className="font-montserrat">
+      {/* Niveau 1 — groupes */}
+      <div
+        className="flex gap-1 overflow-x-auto border-b"
+        style={{ borderColor: NAV_COLORS.border }}
+      >
+        {Array.from(groups.entries()).map(([group, groupItems]) => {
+          const isActive = group === activeGroup
+          return (
+            <button
+              key={group}
+              type="button"
+              // Cliquer un groupe ouvre son premier indicateur : un onglet de groupe
+              // sans sélection laisserait la zone de contenu vide.
+              onClick={() => go(groupItems[0].to)}
+              aria-selected={isActive}
+              className="-mb-px inline-flex flex-shrink-0 items-center gap-2 border-b-[3px] px-4 py-2.5 text-[12.5px] leading-none font-bold tracking-[0.06em] uppercase focus-visible:outline-2 focus-visible:outline-offset-2 md:px-5 md:py-3"
+              style={{
+                borderBottomColor: isActive ? NAV_COLORS.orange : 'transparent',
+                color: isActive ? NAV_COLORS.navy : NAV_COLORS.labelMuted,
+                outlineColor: NAV_COLORS.orange,
+                transition: NAV_TRANSITION,
+              }}
+            >
+              {groupLabel(group)}
+              <span
+                className="rounded-full px-1.5 py-1 text-[10px] leading-none font-bold tabular-nums"
+                style={{
+                  backgroundColor: isActive ? NAV_COLORS.navy : NAV_COLORS.pill,
+                  color: isActive ? '#FFFFFF' : NAV_COLORS.labelMuted,
+                }}
+              >
+                {String(groupItems.length).padStart(2, '0')}
+              </span>
+            </button>
+          )
+        })}
+      </div>
+
+      {/* Niveau 2 — indicateurs du groupe actif */}
+      <div className="flex flex-wrap gap-2 pt-5">
+        {pills.map((item) => {
+          const isActive = item.to === activeItem?.to
+          return (
+            <button
+              key={item.to}
+              type="button"
+              onClick={() => go(item.to)}
+              aria-current={isActive ? 'page' : undefined}
+              className="rounded-full border border-transparent px-3.5 py-[7px] text-[13.5px] leading-[1.2] font-semibold tracking-[-0.005em] active:scale-[.98] focus-visible:outline-2 focus-visible:outline-offset-2 md:px-4 md:py-[9px]"
+              style={{
+                backgroundColor: isActive ? NAV_COLORS.navy : NAV_COLORS.pill,
+                color: isActive ? '#FFFFFF' : NAV_COLORS.navy,
+                outlineColor: NAV_COLORS.orange,
+                transition: NAV_TRANSITION,
+              }}
+            >
+              {item.label}
+            </button>
+          )
+        })}
+      </div>
+    </div>
+  )
+}

--- a/client/src/components/Layout/StatisticLayoutPage.tsx
+++ b/client/src/components/Layout/StatisticLayoutPage.tsx
@@ -1,24 +1,19 @@
-import { Outlet, NavLink, useLocation } from 'react-router-dom'
+import { Outlet } from 'react-router-dom'
 
 import { HeaderComponent } from '@/components/Header'
-import { KeyFiguresHeader } from '@/components/Indicators/KeyFiguresHeader'
+import { KeyFiguresBand } from '@/components/Indicators/KeyFiguresBand'
 import { MethodologySection } from '@/components/Indicators/MethodologySection'
-import { HighlightTitle } from '@/components/ui'
-import { cn } from '@/lib/utils'
+import { IndicatorNav, type IndicatorItem } from '@/components/Layout/IndicatorNav'
 import { useKeyFigures } from '@/hooks/useKeyFigures'
 import { useIndicatorCustomTexts } from '@/hooks/useIndicatorCustomTexts'
 import { useEmbedMode } from '@/hooks/useEmbedMode'
 import { useTranslation } from 'react-i18next'
 import asylumDataHero from '@/assets/refugee-camp-diavata.jpg'
-interface NavLinkItem {
-  label: string
-  to: string
-}
+
 export const StatisticLayoutPage = () => {
   const { records: customTexts } = useIndicatorCustomTexts()
   const keyFigures = useKeyFigures()
   const isEmbed = useEmbedMode()
-  const location = useLocation()
   const { t, i18n } = useTranslation()
   const isGr = i18n.language === 'el'
   const asylumApplicationsInEuropeanUnion = customTexts.filter(ct => ct.name === 'AsylumApplicationsInEuropeanUnion')[0] ?? null
@@ -32,15 +27,18 @@ export const StatisticLayoutPage = () => {
 
   const getCustomText = (name: string) => customTexts.find(ct => ct.name === name) ?? null
 
-  const tabItems: NavLinkItem[] = [
-    { label: (isGr ? asylumApplicationsInEuropeanUnion?.title_gr : asylumApplicationsInEuropeanUnion?.title_en) || t('statistics.fluctuationsAsylumApplicationsEu'), to: 'AsylumApplicationsInEuropeanUnion' },
-    { label: (isGr ? asylumApplicationsInEurope?.title_gr : asylumApplicationsInEurope?.title_en) || t('statistics.euAsylumApplications'), to: 'AsylumApplicationsInEurope' },
-    { label: (isGr ? arrivalsInGreece?.title_gr : arrivalsInGreece?.title_en) || t('statistics.arrivalsGreece'), to: 'ArrivalsInGreece' },
-    { label: (isGr ? asylumSeekersCamps?.title_gr : asylumSeekersCamps?.title_en) || t('statistics.asylumSeekersCamps'), to: 'AsylumSeekersCamps' },
-    { label: (isGr ? asylumApplicationsEvolutionInGreece?.title_gr : asylumApplicationsEvolutionInGreece?.title_en) || t('statistics.asylumEvolutionGreece'), to: 'AsylumApplicationsEvolutionInGreece' },
-    { label: (isGr ? protectionGrantedVsRejected?.title_gr : protectionGrantedVsRejected?.title_en) || t('statistics.firstSecondInstanceDecisionsGreece'), to: 'ProtectionGrantedVsRejected' },
-    { label: (isGr ? courtAsylumProcedures?.title_gr : courtAsylumProcedures?.title_en) || t('statistics.courtAsylumProcedures'), to: 'CourtAsylumProcedures' },
-    { label: (isGr ? recognitionRates?.title_gr : recognitionRates?.title_en) || t('statistics.overallProtectionRate'), to: 'RecognitionRates' },
+  // Les groupes sont portés par la donnée : ajouter un indicateur ne demande pas
+  // de toucher au balisage de la navigation. L'ordre de cette liste fixe à la fois
+  // l'ordre des groupes et celui des pastilles.
+  const tabItems: IndicatorItem[] = [
+    { group: 'europe', label: (isGr ? asylumApplicationsInEuropeanUnion?.title_gr : asylumApplicationsInEuropeanUnion?.title_en) || t('statistics.fluctuationsAsylumApplicationsEu'), to: 'AsylumApplicationsInEuropeanUnion' },
+    { group: 'europe', label: (isGr ? asylumApplicationsInEurope?.title_gr : asylumApplicationsInEurope?.title_en) || t('statistics.euAsylumApplications'), to: 'AsylumApplicationsInEurope' },
+    { group: 'greeceFlows', label: (isGr ? arrivalsInGreece?.title_gr : arrivalsInGreece?.title_en) || t('statistics.arrivalsGreece'), to: 'ArrivalsInGreece' },
+    { group: 'greeceFlows', label: (isGr ? asylumSeekersCamps?.title_gr : asylumSeekersCamps?.title_en) || t('statistics.asylumSeekersCamps'), to: 'AsylumSeekersCamps' },
+    { group: 'greeceFlows', label: (isGr ? asylumApplicationsEvolutionInGreece?.title_gr : asylumApplicationsEvolutionInGreece?.title_en) || t('statistics.asylumEvolutionGreece'), to: 'AsylumApplicationsEvolutionInGreece' },
+    { group: 'decisions', label: (isGr ? protectionGrantedVsRejected?.title_gr : protectionGrantedVsRejected?.title_en) || t('statistics.firstSecondInstanceDecisionsGreece'), to: 'ProtectionGrantedVsRejected' },
+    { group: 'decisions', label: (isGr ? courtAsylumProcedures?.title_gr : courtAsylumProcedures?.title_en) || t('statistics.courtAsylumProcedures'), to: 'CourtAsylumProcedures' },
+    { group: 'decisions', label: (isGr ? recognitionRates?.title_gr : recognitionRates?.title_en) || t('statistics.overallProtectionRate'), to: 'RecognitionRates' },
   ]
   return (
     <div className="app mx-auto my-0 w-full xl:max-w-315">
@@ -63,23 +61,9 @@ export const StatisticLayoutPage = () => {
             {t('statistics.photoCredit')}
           </p>
         </div>
-        {(isGr ? keyFigures.title_gr : keyFigures.title_en) && (
-          <HighlightTitle title={isGr ? keyFigures.title_gr : keyFigures.title_en} />
-        )}
-        <KeyFiguresHeader data={keyFigures} />
-        <div className="flex flex-wrap gap-2 border-b border-gray-200 px-1 py-3">
-          {tabItems.map(tabItem => (
-            <NavLink
-              to={{ pathname: tabItem.to, search: location.search }}
-              key={tabItem.to}
-              className={({ isActive }: { isActive: boolean }) => cn(
-                'bg-gray-100 text-gray-600 hover:bg-gray-200 hover:text-gray-900 rounded-full px-4 py-1.5 text-sm font-medium whitespace-nowrap transition-colors',
-                { 'bg-[#04356C] text-white': isActive },
-              )}
-            >
-              {tabItem.label}
-            </NavLink>
-          ))}
+        <KeyFiguresBand data={keyFigures} />
+        <div className="pt-6">
+          <IndicatorNav items={tabItems} groupLabel={g => t(`statistics.group.${g}`)} />
         </div>
         <Outlet context={{ customTexts, getCustomText }} />
         <MethodologySection customText={getCustomText('Methodology')} />

--- a/client/src/components/Layout/navTokens.ts
+++ b/client/src/components/Layout/navTokens.ts
@@ -1,0 +1,28 @@
+/**
+ * Jetons de la navigation des indicateurs.
+ *
+ * `navy` et `orange` sont les couleurs de marque relevées sur le site du client
+ * (equallegalaid.org) : ce sont déjà celles du bandeau de titre `bg-[#093266]` et
+ * du filet de HighlightTitle. Le handoff design proposait #12305F et #D2622D,
+ * deux approximations — les valeurs de marque priment.
+ *
+ * Les deux teintes dérivées sont calculées à partir d'elles, pas reprises du
+ * handoff : `navyDark` est le bleu assombri de 20 % (survol d'une pastille
+ * active), `orangeLight` l'orange éclairci de 35 % vers le blanc, pour rester
+ * lisible en petit corps sur fond marine.
+ */
+export const NAV_COLORS = {
+  navy: '#093266',
+  navyDark: '#072852',
+  orange: '#D15F36',
+  orangeLight: '#E1977C',
+  textMuted: '#5A6472',
+  labelMuted: '#8B94A1',
+  mutedOnNavy: '#B7C2D4',
+  pill: '#F1F3F6',
+  pillHover: '#E4E8EE',
+  border: '#E3E5E9',
+} as const
+
+/** Transition unique de la maquette, appliquée à tous les éléments interactifs. */
+export const NAV_TRANSITION = 'all .15s cubic-bezier(.2,.8,.2,1)'

--- a/client/src/i18n/locales/el.json
+++ b/client/src/i18n/locales/el.json
@@ -76,6 +76,11 @@
     }
   },
   "statistics": {
+    "group": {
+      "europe": "Ευρώπη",
+      "greeceFlows": "Ελλάδα · ροές",
+      "decisions": "Αποφάσεις"
+    },
     "photoCredit": "Diavata refugee camp, 2022 © Mattia Bidoli",
     "euAsylumApplications": "Αιτήσεις ασύλου στα κράτη μέλη της ΕΕ",
     "fluctuationsAsylumApplicationsEu": "Διακυμάνσεις των αιτήσεων ασύλου στην ΕΕ",

--- a/client/src/i18n/locales/en.json
+++ b/client/src/i18n/locales/en.json
@@ -76,6 +76,11 @@
     }
   },
   "statistics": {
+    "group": {
+      "europe": "Europe",
+      "greeceFlows": "Greece · flows",
+      "decisions": "Decisions"
+    },
     "photoCredit": "Diavata refugee camp, 2022 © Mattia Bidoli",
     "euAsylumApplications": "Asylum applications in EU Member States",
     "fluctuationsAsylumApplicationsEu": "Fluctuations in asylum applications in the EU",

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -31,6 +31,11 @@
 /* Fallback Montserrat si Gotham indisponible */
 @theme {
   --font-gotham: 'Gotham', 'Montserrat', ui-sans-serif, system-ui, sans-serif;
+  /* Gotham n'est auto-hébergée qu'en 400, 800 et 900. Pour les graisses
+     intermédiaires — 500, 600, 700 des libellés, onglets et pastilles — on passe
+     par Montserrat, importée en 400 à 900, plutôt que de laisser le navigateur
+     synthétiser un gras approximatif. */
+  --font-montserrat: 'Montserrat', ui-sans-serif, system-ui, sans-serif;
 }
 
 @theme inline {


### PR DESCRIPTION
Implémentation du handoff design (option 4a), adaptée à la page existante.

**Structure** : la photo est conservée, le bandeau bleu marine s'insère en dessous avec les quatre chiffres clés, puis la navigation à deux niveaux — trois groupes (Europe, Greece · flows, Decisions) et les pastilles du groupe actif. Remplace la rangée plate de huit onglets.

**Couleurs relevées sur le site du client** plutôt que reprises du handoff : `#093266` et `#D15F36`, déjà présentes dans le projet sur le bandeau de titre et le filet de `HighlightTitle`. Le handoff proposait `#12305F` et `#D2622D`, deux approximations. Les teintes dérivées sont recalculées à partir des vraies.

**Correctif de typographie.** Le `body` n'a aucune `font-family` : tout ce qui ne porte pas `font-gotham` tombait sur la police système. Ajout d'un jeton `--font-montserrat` pour les graisses 500 à 700 que Gotham n'a pas en auto-hébergé (seuls 400, 800 et 900 le sont), Gotham restant sur les titres.

**Écarts assumés par rapport au handoff**
- l'ordre des indicateurs est celui de la PR #180, pas celui du handoff qui est antérieur
- le panneau « Now viewing » est écarté : la carte d'indicateur en dessous porte déjà son titre et son graphique
- la photo est conservée, le handoff ne la mentionnait pas

**Détail d'implémentation** : le groupe actif se déduit de l'URL et non d'un état local, pour que les liens profonds et le retour arrière visent le bon groupe.

⚠️ `KeyFiguresHeader` n'est plus utilisé par le layout mais l'est encore par `StatisticPage.tsx`. Laissé en place, à arbitrer.

Vérifié avec `npm run build` (exit 0).