### PR TITLE
chore: supprime les clés i18n en double

### DIFF
--- a/client/src/i18n/locales/el.json
+++ b/client/src/i18n/locales/el.json
@@ -152,8 +152,6 @@
     "play": "Αναπαραγωγή",
     "pause": "Παύση",
     "resetFilters": "Επαναφορά",
-    "byYear": "Ανά έτος",
-    "byMonth": "Ανά μήνα",
     "applicationsEvolutionGreece": "Εξέλιξη αιτήσεων ασύλου στην Ελλάδα",
     "protectionDecisions": "Αποφάσεις διεθνούς προστασίας",
     "firstSecondInstanceDecisionsGreece": "Αποφάσεις Πρώτου και Δεύτερου Βαθμού στην Ελλάδα",

--- a/client/src/i18n/locales/en.json
+++ b/client/src/i18n/locales/en.json
@@ -152,8 +152,6 @@
     "play": "Play",
     "pause": "Pause",
     "resetFilters": "Reset",
-    "byYear": "By year",
-    "byMonth": "By month",
     "applicationsEvolutionGreece": "Asylum Applications Evolution in Greece",
     "protectionDecisions": "Protection Decisions",
     "firstSecondInstanceDecisionsGreece": "First and Second Instance Decisions in Greece",


### PR DESCRIPTION
`byYear` et `byMonth` étaient définies deux fois dans la section `statistics` des deux fichiers de traduction. Les PR #182 et #184 les ont ajoutées chacune de leur côté, à des endroits différents du fichier — git n'a donc rien signalé au merge.

Valeurs identiques, aucun effet à l'exécution. Nettoyage.