### PR TITLE
fix: bleu de la charte #003366 sur tout le site

### DIFF
--- a/client/src/components/Indicators/ApplicationsEvolutionGreeceDetails.tsx
+++ b/client/src/components/Indicators/ApplicationsEvolutionGreeceDetails.tsx
@@ -23,7 +23,7 @@ export function ApplicationsEvolutionGreeceDetails({
   const isGr = i18n.language === 'el'
 
   const chartConfig = {
-    first_applications: { label: t('statistics.firstTime'), color: '#04356C' },
+    first_applications: { label: t('statistics.firstTime'), color: '#003366' },
     subsequent_applications: { label: t('statistics.subsequent'), color: '#6B9BD2' },
   } satisfies ChartConfig
 
@@ -57,7 +57,7 @@ export function ApplicationsEvolutionGreeceDetails({
         {/* Card header */}
         <div className="border-b border-gray-100 bg-gray-50/60 px-6 py-5">
           <div className="flex items-center gap-2">
-            <h2 className="text-xl font-bold whitespace-pre-line" style={{ color: '#04356C' }}>{title}</h2>
+            <h2 className="text-xl font-bold whitespace-pre-line" style={{ color: '#003366' }}>{title}</h2>
             <IndicatorInfoButton text={information} />
           </div>
           {subtitle && <p className="text-muted-foreground mt-1 text-sm whitespace-pre-line">{subtitle}</p>}
@@ -101,7 +101,7 @@ export function ApplicationsEvolutionGreeceDetails({
           {(explanatoryTitle || explanatoryText) && (
             <div className="rounded-lg bg-gray-50 px-4 py-4 space-y-1.5">
               {explanatoryTitle && (
-                <h3 className="text-sm font-semibold whitespace-pre-line" style={{ color: '#04356C' }}>{explanatoryTitle}</h3>
+                <h3 className="text-sm font-semibold whitespace-pre-line" style={{ color: '#003366' }}>{explanatoryTitle}</h3>
               )}
               {explanatoryText && (
                 <p className="text-muted-foreground text-sm leading-relaxed whitespace-pre-line">{explanatoryText}</p>

--- a/client/src/components/Indicators/ArrivalsGreeceDetails.tsx
+++ b/client/src/components/Indicators/ArrivalsGreeceDetails.tsx
@@ -352,7 +352,7 @@ export function ArrivalsGreeceDetails({
         <div className="flex items-start justify-between gap-4 border-b border-gray-100 bg-gray-50/60 px-6 py-5">
           <div>
             <div className="flex items-center gap-2">
-              <h2 className="text-xl font-bold whitespace-pre-line" style={{ color: '#04356C' }}>{title}</h2>
+              <h2 className="text-xl font-bold whitespace-pre-line" style={{ color: '#003366' }}>{title}</h2>
               <IndicatorInfoButton text={information} />
             </div>
             {subtitle && (

--- a/client/src/components/Indicators/AsylumApplicationsDetails.tsx
+++ b/client/src/components/Indicators/AsylumApplicationsDetails.tsx
@@ -44,7 +44,7 @@ export function AsylumApplicationsDetails({
   const chartConfig = {
     first_time_applicants: {
       label: t('statistics.firstTime'),
-      color: '#04356C',
+      color: '#003366',
     },
     subsequent_applicants: {
       label: t('statistics.subsequent'),
@@ -126,7 +126,7 @@ export function AsylumApplicationsDetails({
         <div className="border-b border-gray-100 bg-gray-50/60 px-6 py-5 flex items-start justify-between gap-4">
           <div>
             <div className="flex items-center gap-2">
-              <h2 className="text-xl font-bold whitespace-pre-line" style={{ color: '#04356C' }}>{title}</h2>
+              <h2 className="text-xl font-bold whitespace-pre-line" style={{ color: '#003366' }}>{title}</h2>
               <IndicatorInfoButton text={information} />
             </div>
             {subtitle && (

--- a/client/src/components/Indicators/AsylumApplicationsEvolutionInGreeceDetails.tsx
+++ b/client/src/components/Indicators/AsylumApplicationsEvolutionInGreeceDetails.tsx
@@ -20,7 +20,7 @@ import { CountryOfOriginViews } from './CountryOfOriginViews'
 
 const COLORS = [
   '#003366', '#1E6FA5', '#3F9FD8', '#6BB8E8', '#9AD0F2', '#C5E5F8',
-  '#7C3AED', '#A78BFA', '#B45309', '#D97706', '#065F46', '#059669',
+  '#7C3AED', '#A78BFA', '#9D4729', '#D15F36', '#065F46', '#059669',
 ]
 
 // Aggregate an array of records such that there is only

--- a/client/src/components/Indicators/AsylumApplicationsEvolutionInGreeceDetails.tsx
+++ b/client/src/components/Indicators/AsylumApplicationsEvolutionInGreeceDetails.tsx
@@ -19,7 +19,7 @@ import { useTotalApplicationsGreece, annualTotals, monthlySeries } from '@/hooks
 import { CountryOfOriginViews } from './CountryOfOriginViews'
 
 const COLORS = [
-  '#04356C', '#1E6FA5', '#3F9FD8', '#6BB8E8', '#9AD0F2', '#C5E5F8',
+  '#003366', '#1E6FA5', '#3F9FD8', '#6BB8E8', '#9AD0F2', '#C5E5F8',
   '#7C3AED', '#A78BFA', '#B45309', '#D97706', '#065F46', '#059669',
 ]
 
@@ -167,7 +167,7 @@ function ByPeriod() {
                 />
                 <Bar dataKey="total_applications" radius={[3, 3, 0, 0]}>
                   {yearly.map(y => (
-                    <Cell key={y.year} fill={y.fromMonthly ? '#9AD0F2' : '#04356C'} />
+                    <Cell key={y.year} fill={y.fromMonthly ? '#9AD0F2' : '#003366'} />
                   ))}
                 </Bar>
               </BarChart>
@@ -190,7 +190,7 @@ function ByPeriod() {
                   labelFormatter={label => String(label)}
                 />
                 <Legend iconType="square" iconSize={10} wrapperStyle={{ fontSize: 11 }} />
-                <Bar dataKey="first_applications" stackId="a" name={t('statistics.firstTime')} fill="#04356C" />
+                <Bar dataKey="first_applications" stackId="a" name={t('statistics.firstTime')} fill="#003366" />
                 <Bar dataKey="subsequent_applications" stackId="a" name={t('statistics.subsequent')} fill="#6B9BD2" radius={[3, 3, 0, 0]} />
               </BarChart>
             )}
@@ -406,7 +406,7 @@ export function AsylumApplicationsEvolutionInGreeceDetails({
         {/* Card header */}
         <div className="border-b border-gray-100 bg-gray-50/60 px-6 py-5">
           <div className="flex items-center gap-2">
-            <h2 className="text-xl font-bold whitespace-pre-line" style={{ color: '#04356C' }}>{title}</h2>
+            <h2 className="text-xl font-bold whitespace-pre-line" style={{ color: '#003366' }}>{title}</h2>
             <IndicatorInfoButton text={information} />
           </div>
           {subtitle && (

--- a/client/src/components/Indicators/AsylumSeekersCampsDetails.tsx
+++ b/client/src/components/Indicators/AsylumSeekersCampsDetails.tsx
@@ -16,7 +16,7 @@ const PROTOMAP_KEY = import.meta.env.VITE_PROTOMAP_KEY as string
 
 const REGION_COLORS = [
   '#003366', '#1E6FA5', '#3F9FD8', '#6BB8E8', '#9AD0F2', '#C5E5F8',
-  '#7C3AED', '#A78BFA', '#B45309', '#D97706', '#065F46', '#059669',
+  '#7C3AED', '#A78BFA', '#9D4729', '#D15F36', '#065F46', '#059669',
 ]
 const CAMP_TYPES = [
   "CCAC",
@@ -26,7 +26,7 @@ const CAMP_TYPES = [
 ] as const
 const CAMP_COLORS: Record<string, string> = {
   'CCAC': '#003366',
-  'RIC': '#d97706',
+  'RIC': '#D15F36',
   'Site': '#0090ff',
   'ESTIA': '#7C3AED',
 }

--- a/client/src/components/Indicators/AsylumSeekersCampsDetails.tsx
+++ b/client/src/components/Indicators/AsylumSeekersCampsDetails.tsx
@@ -15,7 +15,7 @@ import 'maplibre-gl/dist/maplibre-gl.css'
 const PROTOMAP_KEY = import.meta.env.VITE_PROTOMAP_KEY as string
 
 const REGION_COLORS = [
-  '#04356C', '#1E6FA5', '#3F9FD8', '#6BB8E8', '#9AD0F2', '#C5E5F8',
+  '#003366', '#1E6FA5', '#3F9FD8', '#6BB8E8', '#9AD0F2', '#C5E5F8',
   '#7C3AED', '#A78BFA', '#B45309', '#D97706', '#065F46', '#059669',
 ]
 const CAMP_TYPES = [
@@ -25,7 +25,7 @@ const CAMP_TYPES = [
   "ESTIA",
 ] as const
 const CAMP_COLORS: Record<string, string> = {
-  'CCAC': '#04356C',
+  'CCAC': '#003366',
   'RIC': '#d97706',
   'Site': '#0090ff',
   'ESTIA': '#7C3AED',
@@ -45,7 +45,7 @@ const AREA_ORDER = ['Southern Greece', 'Northern Greece', 'Aegean Islands', 'Cre
 // Marine et orange sont ceux de la marque ; le vert et le violet viennent de la
 // palette Okabe-Ito, qui reste lisible avec un daltinisme deutan ou protan.
 const AREA_COLORS: Record<string, string> = {
-  'Southern Greece': '#093266',
+  'Southern Greece': '#003366',
   'Northern Greece': '#D15F36',
   'Aegean Islands': '#009E73',
   'Crete': '#CC79A7',
@@ -549,7 +549,7 @@ export function AsylumSeekersCampsDetails({
         <div className="border-b border-gray-100 bg-gray-50/60 px-6 py-5 flex flex-wrap items-start justify-between gap-4">
           <div>
             <div className="flex items-center gap-2">
-              <h2 className="text-xl font-bold whitespace-pre-line" style={{ color: '#04356C' }}>{title}</h2>
+              <h2 className="text-xl font-bold whitespace-pre-line" style={{ color: '#003366' }}>{title}</h2>
               <IndicatorInfoButton text={information} />
             </div>
             {/* whitespace-pre-line : les sauts de ligne saisis dans Airtable sont
@@ -580,7 +580,7 @@ export function AsylumSeekersCampsDetails({
                     setPlaying(false)
                     setSelectedMonthIndex(Number(e.target.value))
                   }}
-                  className="w-40 accent-[#04356C]"
+                  className="w-40 accent-[#003366]"
                   aria-label={t('statistics.year')}
                 />
                 <span className="w-24 flex-shrink-0 text-xs tabular-nums text-gray-700">

--- a/client/src/components/Indicators/CountryAlluvial.tsx
+++ b/client/src/components/Indicators/CountryAlluvial.tsx
@@ -12,7 +12,7 @@ import type { AsylumApplicationByNationalityRecord } from '@/hooks/useGreeceTota
  */
 
 const PALETTE = [
-  '#093266', '#1E6FA5', '#3F9FD8', '#6BB8E8',
+  '#003366', '#1E6FA5', '#3F9FD8', '#6BB8E8',
   '#D15F36', '#E1977C', '#7C3AED', '#059669',
 ]
 const OTHER_COLOR = '#CBD3DE'

--- a/client/src/components/Indicators/CountryOfOriginViews.tsx
+++ b/client/src/components/Indicators/CountryOfOriginViews.tsx
@@ -18,10 +18,10 @@ const ISLANDS_COLOR = '#1E6FA5'
 const MAINLAND_COLOR = '#D97706'
 // Bleu primaire de la charte. La Grèce est un aplat de pays, pas une bulle : la
 // forme suffit à la distinguer des origines, pas besoin d'une couleur d'accent.
-const GREECE_COLOR = '#04356C'
+const GREECE_COLOR = '#003366'
 
 const COUNTRY_PALETTE = [
-  '#04356C', '#1E6FA5', '#3F9FD8', '#6BB8E8', '#7C3AED',
+  '#003366', '#1E6FA5', '#3F9FD8', '#6BB8E8', '#7C3AED',
   '#A78BFA', '#B45309', '#059669', '#94a3b8',
 ]
 

--- a/client/src/components/Indicators/CourtAsylumProceduresDetails.tsx
+++ b/client/src/components/Indicators/CourtAsylumProceduresDetails.tsx
@@ -10,7 +10,7 @@ import type { ChartConfig } from '@/components/ui'
 import { useTranslation } from 'react-i18next'
 
 const GRANTED_COLOR = '#3F9FD8'
-const REJECTED_COLOR = '#04356C'
+const REJECTED_COLOR = '#003366'
 const INADMISSIBLE_COLOR = '#6BB8E8'
 const WITHDRAWALS_COLOR = '#9AD0F2'
 const ACCEPTED_GREEN = '#059669'
@@ -377,7 +377,7 @@ export function CourtAsylumProceduresDetails({
       <div className="overflow-hidden rounded-xl border border-gray-200 bg-white shadow-sm">
         <div className="border-b border-gray-100 bg-gray-50/60 px-6 py-5">
           <div className="flex items-center gap-2">
-            <h2 className="text-xl font-bold whitespace-pre-line" style={{ color: '#04356C' }}>{title}</h2>
+            <h2 className="text-xl font-bold whitespace-pre-line" style={{ color: '#003366' }}>{title}</h2>
             <IndicatorInfoButton text={information} />
           </div>
           {subtitle && <p className="text-muted-foreground mt-1 text-sm whitespace-pre-line">{subtitle}</p>}
@@ -393,7 +393,7 @@ export function CourtAsylumProceduresDetails({
         {(explanatoryTitle || explanatoryText) && (
           <div className="space-y-1.5 rounded-lg border border-gray-200 bg-gray-50 px-4 py-4">
             {explanatoryTitle && (
-              <h3 className="text-sm font-semibold whitespace-pre-line" style={{ color: '#04356C' }}>{explanatoryTitle}</h3>
+              <h3 className="text-sm font-semibold whitespace-pre-line" style={{ color: '#003366' }}>{explanatoryTitle}</h3>
             )}
             {explanatoryText && (
               <p className="text-muted-foreground text-sm leading-relaxed whitespace-pre-line text-justify">{explanatoryText}</p>

--- a/client/src/components/Indicators/DecisionsEvolutionBarChart.tsx
+++ b/client/src/components/Indicators/DecisionsEvolutionBarChart.tsx
@@ -6,7 +6,7 @@ import type { DecisionsYearly } from '@/hooks/useProtectionDecisions'
 
 const GRANTED_LIGHT = '#3F9FD8'
 const GRANTED_DARK = '#0B4C82'
-const REJECTED_DARK = '#04356C'
+const REJECTED_DARK = '#003366'
 const REJECTED_MID = '#6BB8E8'
 const REJECTED_LIGHT = '#9AD0F2'
 

--- a/client/src/components/Indicators/DonutPage.tsx
+++ b/client/src/components/Indicators/DonutPage.tsx
@@ -23,7 +23,7 @@ function createDataForAllYear(records: AsylumApplicationRecord[]) {
   }
 
   const dataForAllYear: PieChartData[] = [
-    { name: 'First Time Applicants', value: total_first_time, color: '#04356C', link: 'chart_first_applicants' },
+    { name: 'First Time Applicants', value: total_first_time, color: '#003366', link: 'chart_first_applicants' },
     { name: 'Subsequent Applicants', value: total_subsequent, color: '#6B9BD2', link: 'chart_subsequent_applicants' },
   ]
   return dataForAllYear

--- a/client/src/components/Indicators/EuropeRegionMap.tsx
+++ b/client/src/components/Indicators/EuropeRegionMap.tsx
@@ -291,7 +291,7 @@ export function EuropeRegionMap({ customText }: { customText?: IndicatorCustomTe
         {/* Card header */}
         <div className="border-b border-gray-100 bg-gray-50/60 px-6 py-5">
           <div className="flex items-center gap-2">
-            <h2 className="text-xl font-bold whitespace-pre-line" style={{ color: '#04356C' }}>{title}</h2>
+            <h2 className="text-xl font-bold whitespace-pre-line" style={{ color: '#003366' }}>{title}</h2>
             <IndicatorInfoButton text={information} />
           </div>
           {subtitle && (

--- a/client/src/components/Indicators/KeyFiguresBand.tsx
+++ b/client/src/components/Indicators/KeyFiguresBand.tsx
@@ -71,7 +71,9 @@ export function KeyFiguresBand({ data }: { data: KeyFiguresData }) {
               {title}
             </h2>
             <div
-              className="mx-auto mt-4 h-[5px] w-[88px] rounded-[3px]"
+              // Format du filet du site officiel : 7 px sur 50, bouts carrés.
+              // Même trait que HighlightTitle, pour que les deux titres se répondent.
+              className="mx-auto mt-4 h-[7px] w-[50px]"
               style={{ backgroundColor: NAV_COLORS.orange }}
             />
           </div>

--- a/client/src/components/Indicators/ProtectionDecisionsDetails.tsx
+++ b/client/src/components/Indicators/ProtectionDecisionsDetails.tsx
@@ -12,7 +12,7 @@ import { useTranslation } from 'react-i18next'
 import { DecisionsEvolutionBarChart } from './DecisionsEvolutionBarChart'
 
 const GRANTED_COLOR = '#3F9FD8'
-const REJECTED_COLOR = '#04356C'
+const REJECTED_COLOR = '#003366'
 
 function TreeRow({
   label,
@@ -336,7 +336,7 @@ export function ProtectionDecisionsDetails({
         {/* Card header */}
         <div className="border-b border-gray-100 bg-gray-50/60 px-6 py-5">
           <div className="flex items-center gap-2">
-            <h2 className="text-xl font-bold whitespace-pre-line" style={{ color: '#04356C' }}>{title}</h2>
+            <h2 className="text-xl font-bold whitespace-pre-line" style={{ color: '#003366' }}>{title}</h2>
             <IndicatorInfoButton text={information} />
           </div>
           {subtitle && <p className="text-muted-foreground mt-1 text-sm whitespace-pre-line">{subtitle}</p>}
@@ -347,11 +347,11 @@ export function ProtectionDecisionsDetails({
 
           {/* Tab Trigger */}
           <Tabs.List className="rounded-md bg-gray-100 p-1 mt-6 w-max flex items-center">
-            <Tabs.Trigger className="rounded-sm px-3 py-1.5 leading-none data-[state=active]:shadow data-[state=active]:bg-[#04356C] data-[state=active]:text-white" value="tab1">
+            <Tabs.Trigger className="rounded-sm px-3 py-1.5 leading-none data-[state=active]:shadow data-[state=active]:bg-[#003366] data-[state=active]:text-white" value="tab1">
               {t('statistics.firstInstanceDecisions')}
             </Tabs.Trigger>
             {" > "}
-            <Tabs.Trigger className="rounded-sm px-3 py-1.5 leading-none data-[state=active]:shadow data-[state=active]:bg-[#04356C] data-[state=active]:text-white" value="tab2">
+            <Tabs.Trigger className="rounded-sm px-3 py-1.5 leading-none data-[state=active]:shadow data-[state=active]:bg-[#003366] data-[state=active]:text-white" value="tab2">
               {t('statistics.appealsDecisions')}
             </Tabs.Trigger>
           </Tabs.List>
@@ -377,7 +377,7 @@ export function ProtectionDecisionsDetails({
           {(explanatoryTitle || explanatoryText) && (
             <div className="rounded-lg border border-gray-200 bg-gray-50 px-4 py-4 space-y-1.5">
               {explanatoryTitle && (
-                <h3 className="text-sm font-semibold whitespace-pre-line" style={{ color: '#04356C' }}>{explanatoryTitle}</h3>
+                <h3 className="text-sm font-semibold whitespace-pre-line" style={{ color: '#003366' }}>{explanatoryTitle}</h3>
               )}
               {explanatoryText && (
                 <p className="text-muted-foreground text-sm leading-relaxed whitespace-pre-line text-justify">{explanatoryText}</p>

--- a/client/src/components/Indicators/RecognitionRatesDetails.tsx
+++ b/client/src/components/Indicators/RecognitionRatesDetails.tsx
@@ -9,7 +9,7 @@ import { ChartContainer, IndicatorInfoButton } from '@/components/ui'
 import { useTranslation } from 'react-i18next'
 
 const GRANTED_COLOR = '#3F9FD8'
-const REJECTED_COLOR = '#04356C'
+const REJECTED_COLOR = '#003366'
 
 function TreeRow({
   label,
@@ -65,7 +65,7 @@ function InstanceTable({ record }: { record: RecognitionRateRecord }) {
   return (
     <div className="min-w-0 overflow-x-auto rounded-lg border border-gray-200">
       <table className="w-full text-sm">
-        <thead className="bg-[#04356C] text-xs tracking-wide text-white uppercase">
+        <thead className="bg-[#003366] text-xs tracking-wide text-white uppercase">
           <tr>
             <th className="px-4 py-2 text-left">{t('statistics.decisionType')}</th>
             <th className="px-4 py-2 text-right">{t('statistics.count')}</th>
@@ -186,7 +186,7 @@ export function RecognitionRatesDetails({
         {/* Card header */}
         <div className="border-b border-gray-100 bg-gray-50/60 px-6 py-5">
           <div className="flex items-center gap-2">
-            <h2 className="text-xl font-bold whitespace-pre-line" style={{ color: '#04356C' }}>{title}</h2>
+            <h2 className="text-xl font-bold whitespace-pre-line" style={{ color: '#003366' }}>{title}</h2>
             <IndicatorInfoButton text={information} />
           </div>
           {subtitle && <p className="text-muted-foreground mt-1 text-sm whitespace-pre-line">{subtitle}</p>}
@@ -199,7 +199,7 @@ export function RecognitionRatesDetails({
           {(explanatoryTitle || explanatoryText) && (
             <div className="rounded-lg border border-gray-200 bg-gray-50 px-4 py-4 space-y-1.5">
               {explanatoryTitle && (
-                <h3 className="text-sm font-semibold whitespace-pre-line" style={{ color: '#04356C' }}>{explanatoryTitle}</h3>
+                <h3 className="text-sm font-semibold whitespace-pre-line" style={{ color: '#003366' }}>{explanatoryTitle}</h3>
               )}
               {explanatoryText && (
                 <p className="text-muted-foreground text-sm leading-relaxed whitespace-pre-line text-justify">{explanatoryText}</p>

--- a/client/src/components/Layout/StatisticLayoutPage.tsx
+++ b/client/src/components/Layout/StatisticLayoutPage.tsx
@@ -52,7 +52,7 @@ export const StatisticLayoutPage = () => {
           />
           <div className="absolute bottom-10 left-0 w-full pl-[5%] xl:bottom-[72px]">
             <h1 className="max-w-[800px]">
-              <span className="font-gotham bg-[#093266] px-5 text-[32px] font-extrabold uppercase leading-tight tracking-[0.3px] text-white xl:text-[48px] [box-decoration-break:clone] [-webkit-box-decoration-break:clone]">
+              <span className="font-gotham bg-[#003366] px-5 text-[32px] font-extrabold uppercase leading-tight tracking-[0.3px] text-white xl:text-[48px] [box-decoration-break:clone] [-webkit-box-decoration-break:clone]">
                 {t('nav.statistics')}
               </span>
             </h1>

--- a/client/src/components/Layout/navTokens.ts
+++ b/client/src/components/Layout/navTokens.ts
@@ -1,10 +1,8 @@
 /**
  * Jetons de la navigation des indicateurs.
  *
- * `navy` et `orange` sont les couleurs de marque relevées sur le site du client
- * (equallegalaid.org) : ce sont déjà celles du bandeau de titre `bg-[#093266]` et
- * du filet de HighlightTitle. Le handoff design proposait #12305F et #D2622D,
- * deux approximations — les valeurs de marque priment.
+ * `navy` et `orange` sont les couleurs de la charte du site : #003366 et #D15F36.
+ * Ce sont celles du bandeau de titre `bg-[#003366]` et du filet de HighlightTitle.
  *
  * Les deux teintes dérivées sont calculées à partir d'elles, pas reprises du
  * handoff : `navyDark` est le bleu assombri de 20 % (survol d'une pastille
@@ -12,8 +10,8 @@
  * lisible en petit corps sur fond marine.
  */
 export const NAV_COLORS = {
-  navy: '#093266',
-  navyDark: '#072852',
+  navy: '#003366',
+  navyDark: '#002952',
   orange: '#D15F36',
   orangeLight: '#E1977C',
   textMuted: '#5A6472',

--- a/client/src/components/Pages/StatisticPage.tsx
+++ b/client/src/components/Pages/StatisticPage.tsx
@@ -49,7 +49,7 @@ export default function StatisticPage() {
             key={i}
             onClick={() => setActiveTab(i)}
             className={`rounded-full px-4 py-1.5 text-sm font-medium whitespace-nowrap transition-colors ${activeTab === i
-                ? 'bg-[#04356C] text-white'
+                ? 'bg-[#003366] text-white'
                 : 'bg-gray-100 text-gray-600 hover:bg-gray-200 hover:text-gray-900'
               }`}
           >

--- a/client/src/pages/CaselawPage.tsx
+++ b/client/src/pages/CaselawPage.tsx
@@ -44,7 +44,7 @@ export const CaselawPage = () => {
         />
         <div className="absolute bottom-10 left-0 w-full pl-[5%] xl:bottom-[72px]">
           <h1 className="max-w-[800px]">
-            <span className="font-gotham bg-[#093266] px-5 text-[32px] font-extrabold uppercase leading-tight tracking-[0.3px] text-white xl:text-[48px] [box-decoration-break:clone] [-webkit-box-decoration-break:clone]">
+            <span className="font-gotham bg-[#003366] px-5 text-[32px] font-extrabold uppercase leading-tight tracking-[0.3px] text-white xl:text-[48px] [box-decoration-break:clone] [-webkit-box-decoration-break:clone]">
               {t('nav.caselaw')}
             </span>
           </h1>


### PR DESCRIPTION
Trois bleus marine coexistaient dans le code, et **aucun n'était celui de la charte** :

| Valeur | Occurrences | Où |
|---|---|---|
| `#04356C` | 32 | bleu de référence des graphiques et des titres d'indicateurs |
| `#093266` | 6 | bandeau de titre `bg-[#093266]`, `navTokens.ts` |
| `#003366` | 1 | `index.css`, sous `--logo` — la seule bonne |

La charte du site est **#003366** (bleu foncé), **#D1EFF9** (bleu clair), **#D15F36** (orange). Les 38 occurrences des deux mauvaises valeurs passent sur `#003366`.

`navTokens.navyDark` est recalculé depuis cette base : `#002952` au lieu de `#072852`, qui dérivait du faux bleu.

Changement purement mécanique — une seule valeur de couleur, aucune logique touchée. Vérifié à l'écran sur les indicateurs Décisions et Arrivals : en-têtes de tableau, camemberts et graphiques rendent correctement.